### PR TITLE
feat: Add log level options

### DIFF
--- a/waku.go
+++ b/waku.go
@@ -17,7 +17,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	lvl, err := logging.LevelFromString("info")
+	lvl, err := logging.LevelFromString(options.LogLevel)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/waku/options.go
+++ b/waku/options.go
@@ -71,6 +71,7 @@ type Options struct {
 	KeepAlive   int      `long:"keep-alive" default:"20" description:"Interval in seconds for pinging peers to keep the connection alive."`
 	UseDB       bool     `long:"use-db" description:"Use SQLiteDB to persist information"`
 	DBPath      string   `long:"dbpath" default:"./store.db" description:"Path to DB file"`
+	LogLevel    string   `short:"l" long:"log-level" description:"Define the logging level, supported strings are: DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, and their lower-case forms." default:"INFO"`
 
 	Relay            RelayOptions            `group:"Relay Options"`
 	Store            StoreOptions            `group:"Store Options"`


### PR DESCRIPTION
fixes #47

help:
```
Application Options:
  -p, --port=                     Libp2p TCP listening port (0 for random) (default: 9000)
      --ws                        Enable websockets support
      --ws-port=                  Libp2p TCP listening port for websocket connection (0 for random) (default: 9001)
      --nodekey=                  P2P node private key as hex. Can also be set with GOWAKU-NODEKEY env variable (default random)
      --key-file=                 Path to a file containing the private key for the P2P node (default: ./nodekey)
      --generate-key              Generate private key file at path specified in --key-file
      --overwrite                 When generating a keyfile, overwrite the nodekey file if it already exists
      --static-node=              Multiaddr of peer to directly connect with. Option may be repeated
      --keep-alive=               Interval in seconds for pinging peers to keep the connection alive. (default: 20)
      --use-db                    Use SQLiteDB to persist information
      --dbpath=                   Path to DB file (default: ./store.db)
  -l, --log-level=                Define the logging level, supported strings are: DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, and their lower-case forms. (default: INFO)

```