### PR TITLE
metrics: add /health endpoint for healthchecks

### DIFF
--- a/waku/metrics/http.go
+++ b/waku/metrics/http.go
@@ -40,6 +40,11 @@ func NewMetricsServer(address string, port int) *Server {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", pe)
 
+	// Healthcheck
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "OK")
+	})
+
 	h := &ochttp.Handler{Handler: mux}
 
 	// Register the views


### PR DESCRIPTION
Because calling `/metrics` for a Consul healhcheck is too heavy and far too verbose.