### PR TITLE
ci: add GitHub username to build notifications

### DIFF
--- a/ci/Jenkinsfile.docker
+++ b/ci/Jenkinsfile.docker
@@ -61,37 +61,50 @@ pipeline {
   }
   post {
     success { script {
-      withCredentials([
-        string(
-          credentialsId: 'discord-waku-deployments-webhook',
-          variable: 'DISCORD_WEBHOOK'
-        ),
-      ]) {
-        def repo = [
-          url: 'https://github.com/status-im/go-waku',
-          branch: GIT_BRANCH.minus("origin/"),
-          commit: GIT_COMMIT.take(8),
-          prev: (env.GIT_PREVIOUS_SUCCESSFUL_COMMIT ?: env.GIT_PREVIOUS_COMMIT ?: 'master').take(8),
-        ]
-        wrap([$class: 'BuildUser']) {
-          BUILD_USER_ID = env.BUILD_USER_ID
-        }
-        discordSend(
-          title: "${env.JOB_NAME}#${env.BUILD_NUMBER}",
-          description: """
-            Go-Waku deployment successful!
-            Image: [`${IMAGE_NAME}:${IMAGE_TAG}`](https://hub.docker.com/r/${IMAGE_NAME}/tags?name=${IMAGE_TAG})
-            Branch: [`${repo.branch}`](${repo.url}/commits/${repo.branch})
-            Commit: [`${repo.commit}`](${repo.url}/commit/${repo.commit})
-            Diff: [`${repo.prev}...${repo.commit}`](${repo.url}/compare/${repo.prev}...${repo.commit})
-            By: [`${BUILD_USER_ID}`](${repo.url}/commits?author=${BUILD_USER_ID})
-          """,
-          link: env.BUILD_URL,
-          result: currentBuild.currentResult,
-          webhookURL: env.DISCORD_WEBHOOK
-        )
-      }
+      discordNotify(
+        header: 'Go-Waku deployment successful!',
+        cred: 'discord-waku-deployments-webhook',
+      )
     } }
     always { cleanWs() }
+  }
+}
+
+def discordNotify(Map args=[:]) {
+  def opts = [
+    header: args.header ?: 'Deployment successful!',
+    cred: args.cred ?: null,
+  ]
+  def repo = [
+    url: GIT_URL.minus('.git'),
+    branch: GIT_BRANCH.minus('origin/'),
+    commit: GIT_COMMIT.take(8),
+    prev: (
+      env.GIT_PREVIOUS_SUCCESSFUL_COMMIT ?: env.GIT_PREVIOUS_COMMIT ?: 'master'
+    ).take(8),
+  ]
+  wrap([$class: 'BuildUser']) {
+    BUILD_USER_ID = env.BUILD_USER_ID
+  }
+  withCredentials([
+    string(
+      credentialsId: opts.cred,
+      variable: 'DISCORD_WEBHOOK',
+    ),
+  ]) {
+    discordSend(
+      link: env.BUILD_URL,
+      result: currentBuild.currentResult,
+      webhookURL: env.DISCORD_WEBHOOK,
+      title: "${env.JOB_NAME}#${env.BUILD_NUMBER}",
+      description: """
+        ${opts.header}
+        Image: [`${IMAGE_NAME}:${IMAGE_TAG}`](https://hub.docker.com/r/${IMAGE_NAME}/tags?name=${IMAGE_TAG})
+        Branch: [`${repo.branch}`](${repo.url}/commits/${repo.branch})
+        Commit: [`${repo.commit}`](${repo.url}/commit/${repo.commit})
+        Diff: [`${repo.prev}...${repo.commit}`](${repo.url}/compare/${repo.prev}...${repo.commit})
+        By: [`${BUILD_USER_ID}`](${repo.url}/commits?author=${BUILD_USER_ID})
+      """,
+    )
   }
 }


### PR DESCRIPTION
Makes it easier to identify who to talk to about a deployment.

This depends on the following plugin being installed:
https://plugins.jenkins.io/build-user-vars-plugin/