### PR TITLE
refactor: discv5 codebase

### DIFF
--- a/cmd/waku/flags.go
+++ b/cmd/waku/flags.go
@@ -389,31 +389,6 @@ var (
 		},
 		EnvVars: []string{"WAKUNODE2_LIGHTPUSHNODE"},
 	})
-	Discv5Discovery = altsrc.NewBoolFlag(&cli.BoolFlag{
-		Name:        "discv5-discovery",
-		Usage:       "Enable discovering nodes via Node Discovery v5",
-		Destination: &options.DiscV5.Enable,
-		EnvVars:     []string{"WAKUNODE2_DISCV5_DISCOVERY"},
-	})
-	Discv5BootstrapNode = altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
-		Name:        "discv5-bootstrap-node",
-		Usage:       "Text-encoded ENR for bootstrap node. Used when connecting to the network. Option may be repeated",
-		Destination: &options.DiscV5.Nodes,
-		EnvVars:     []string{"WAKUNODE2_DISCV5_BOOTSTRAP_NODE"},
-	})
-	Discv5UDPPort = altsrc.NewUintFlag(&cli.UintFlag{
-		Name:        "discv5-udp-port",
-		Value:       9000,
-		Usage:       "Listening UDP port for Node Discovery v5.",
-		Destination: &options.DiscV5.Port,
-		EnvVars:     []string{"WAKUNODE2_DISCV5_UDP_PORT"},
-	})
-	Discv5ENRAutoUpdate = altsrc.NewBoolFlag(&cli.BoolFlag{
-		Name:        "discv5-enr-auto-update",
-		Usage:       "Discovery can automatically update its ENR with the IP address as seen by other nodes it communicates with.",
-		Destination: &options.DiscV5.AutoUpdate,
-		EnvVars:     []string{"WAKUNODE2_DISCV5_ENR_AUTO_UPDATE"},
-	})
 	Rendezvous = altsrc.NewBoolFlag(&cli.BoolFlag{
 		Name:        "rendezvous",
 		Usage:       "Enable rendezvous protocol for peer discovery",

--- a/cmd/waku/main.go
+++ b/cmd/waku/main.go
@@ -12,6 +12,10 @@ import (
 	"go.uber.org/zap"
 )
 
+type CliFlagsI interface {
+	CliFlags() []cli.Flag
+}
+
 var options NodeOptions
 
 func main() {
@@ -74,10 +78,6 @@ func main() {
 		FilterLegacyLightClient,
 		LightPush,
 		LightPushNode,
-		Discv5Discovery,
-		Discv5BootstrapNode,
-		Discv5UDPPort,
-		Discv5ENRAutoUpdate,
 		PeerExchange,
 		PeerExchangeNode,
 		DNSDiscovery,
@@ -100,6 +100,12 @@ func main() {
 		RESTRelayCacheCapacity,
 		RESTAdmin,
 		PProf,
+	}
+	//
+	for _, obj := range []CliFlagsI{
+		&options.DiscV5,
+	} {
+		cliFlags = append(cliFlags, obj.CliFlags()...)
 	}
 
 	rlnFlags := rlnFlags()

--- a/cmd/waku/options.go
+++ b/cmd/waku/options.go
@@ -8,16 +8,8 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	"github.com/urfave/cli/v2"
 	"github.com/waku-org/go-waku/waku/cliutils"
+	"github.com/waku-org/go-waku/waku/v2/discv5"
 )
-
-// DiscV5Options are settings to enable a modified version of Ethereum’s Node
-// Discovery Protocol v5 as a means for ambient node discovery.
-type DiscV5Options struct {
-	Enable     bool
-	Nodes      cli.StringSlice
-	Port       uint
-	AutoUpdate bool
-}
 
 // RelayOptions are settings to enable the relay protocol which is a pubsub
 // approach to peer-to-peer messaging with a strong focus on privacy,
@@ -179,10 +171,11 @@ type NodeOptions struct {
 	Filter       FilterOptions
 	LightPush    LightpushOptions
 	RLNRelay     RLNRelayOptions
-	DiscV5       DiscV5Options
 	DNSDiscovery DNSDiscoveryOptions
 	Rendezvous   RendezvousOptions
 	Metrics      MetricsOptions
 	RPCServer    RPCServerOptions
 	RESTServer   RESTServerOptions
+	//
+	DiscV5 discv5.DiscV5Parameters
 }

--- a/library/node.go
+++ b/library/node.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/waku-org/go-waku/waku/persistence"
 	dbutils "github.com/waku-org/go-waku/waku/persistence/utils"
+	"github.com/waku-org/go-waku/waku/v2/discv5"
 	"github.com/waku-org/go-waku/waku/v2/node"
 	"github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
@@ -153,7 +154,7 @@ func NewNode(configJSON string) error {
 			}
 			bootnodes = append(bootnodes, bootnode)
 		}
-		opts = append(opts, node.WithDiscoveryV5(*config.DiscV5UDPPort, bootnodes, true))
+		opts = append(opts, node.WithDiscoveryV5(discv5.GetDiscv5Params(*config.DiscV5UDPPort, bootnodes, true)))
 	}
 
 	wakuState.relayTopics = config.RelayTopics

--- a/waku/v2/discv5/discover.go
+++ b/waku/v2/discv5/discover.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/multiformats/go-multiaddr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/waku-org/go-discover/discover"
 	"github.com/waku-org/go-waku/logging"
@@ -32,7 +31,7 @@ type PeerConnector interface {
 }
 
 type DiscoveryV5 struct {
-	params    *discV5Parameters
+	params    *DiscV5Parameters
 	host      host.Host
 	config    discover.Config
 	udpAddr   *net.UDPAddr
@@ -48,59 +47,13 @@ type DiscoveryV5 struct {
 	*peermanager.CommonDiscoveryService
 }
 
-type discV5Parameters struct {
-	autoUpdate    bool
-	autoFindPeers bool
-	bootnodes     []*enode.Node
-	udpPort       uint
-	advertiseAddr []multiaddr.Multiaddr
-	loopPredicate func(*enode.Node) bool
-}
-
-type DiscoveryV5Option func(*discV5Parameters)
+type DiscoveryV5Option func(*DiscV5Parameters)
 
 var protocolID = [6]byte{'d', '5', 'w', 'a', 'k', 'u'}
 
 const peerDelay = 100 * time.Millisecond
 const bucketSize = 16
 const delayBetweenDiscoveredPeerCnt = 5 * time.Second
-
-func WithAutoUpdate(autoUpdate bool) DiscoveryV5Option {
-	return func(params *discV5Parameters) {
-		params.autoUpdate = autoUpdate
-	}
-}
-
-// WithBootnodes is an option used to specify the bootstrap nodes to use with DiscV5
-func WithBootnodes(bootnodes []*enode.Node) DiscoveryV5Option {
-	return func(params *discV5Parameters) {
-		params.bootnodes = bootnodes
-	}
-}
-
-func WithAdvertiseAddr(addr []multiaddr.Multiaddr) DiscoveryV5Option {
-	return func(params *discV5Parameters) {
-		params.advertiseAddr = addr
-	}
-}
-
-func WithUDPPort(port uint) DiscoveryV5Option {
-	return func(params *discV5Parameters) {
-		params.udpPort = port
-	}
-}
-
-func WithPredicate(predicate func(*enode.Node) bool) DiscoveryV5Option {
-	return func(params *discV5Parameters) {
-		params.loopPredicate = predicate
-	}
-}
-
-func WithAutoFindPeers(find bool) DiscoveryV5Option {
-	return func(params *discV5Parameters) {
-		params.autoFindPeers = find
-	}
-}
 
 // DefaultOptions contains the default list of options used when setting up DiscoveryV5
 func DefaultOptions() []DiscoveryV5Option {
@@ -112,7 +65,7 @@ func DefaultOptions() []DiscoveryV5Option {
 
 // NewDiscoveryV5 returns a new instance of a DiscoveryV5 struct
 func NewDiscoveryV5(priv *ecdsa.PrivateKey, localnode *enode.LocalNode, peerConnector PeerConnector, reg prometheus.Registerer, log *zap.Logger, opts ...DiscoveryV5Option) (*DiscoveryV5, error) {
-	params := new(discV5Parameters)
+	params := new(DiscV5Parameters)
 	optList := DefaultOptions()
 	optList = append(optList, opts...)
 	for _, opt := range optList {
@@ -142,7 +95,7 @@ func NewDiscoveryV5(priv *ecdsa.PrivateKey, localnode *enode.LocalNode, peerConn
 		},
 		udpAddr: &net.UDPAddr{
 			IP:   net.IPv4zero,
-			Port: int(params.udpPort),
+			Port: int(params.UdpPort),
 		},
 		log: logger,
 	}, nil

--- a/waku/v2/discv5/option.go
+++ b/waku/v2/discv5/option.go
@@ -1,0 +1,132 @@
+package discv5
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/prometheus/client_golang/prometheus"
+	cli "github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2/altsrc"
+	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
+	"go.uber.org/zap"
+)
+
+type DiscV5Parameters struct {
+	// used by localNode
+	AutoUpdate bool
+	UdpPort    uint
+	// for cli
+	clinodes cli.StringSlice
+	//
+	enable        bool
+	autoFindPeers bool
+	bootnodes     []*enode.Node
+	advertiseAddr []multiaddr.Multiaddr
+	loopPredicate func(*enode.Node) bool
+}
+
+func (params *DiscV5Parameters) CliFlags() []cli.Flag {
+	return []cli.Flag{
+		altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:        "discv5-discovery",
+			Usage:       "Enable discovering nodes via Node Discovery v5",
+			Destination: &params.enable,
+			EnvVars:     []string{"WAKUNODE2_DISCV5_DISCOVERY"},
+		}), altsrc.NewStringSliceFlag(&cli.StringSliceFlag{
+			Name:        "discv5-bootstrap-node",
+			Usage:       "Text-encoded ENR for bootstrap node. Used when connecting to the network. Option may be repeated",
+			Destination: &params.clinodes,
+			EnvVars:     []string{"WAKUNODE2_DISCV5_BOOTSTRAP_NODE"},
+		}), altsrc.NewUintFlag(&cli.UintFlag{
+			Name:        "discv5-udp-port",
+			Value:       9000,
+			Usage:       "Listening UDP port for Node Discovery v5.",
+			Destination: &params.UdpPort,
+			EnvVars:     []string{"WAKUNODE2_DISCV5_UDP_PORT"},
+		}), altsrc.NewBoolFlag(&cli.BoolFlag{
+			Name:        "discv5-enr-auto-update",
+			Usage:       "Discovery can automatically update its ENR with the IP address as seen by other nodes it communicates with.",
+			Destination: &params.AutoUpdate,
+			EnvVars:     []string{"WAKUNODE2_DISCV5_ENR_AUTO_UPDATE"},
+		}),
+	}
+}
+
+func GetDiscv5Params(udpPort uint, bootnodes []*enode.Node, autoUpdate bool) DiscV5Parameters {
+	return DiscV5Parameters{
+		enable:     true,
+		UdpPort:    udpPort,
+		bootnodes:  bootnodes,
+		AutoUpdate: autoUpdate,
+	}
+}
+func WithAutoUpdate(autoUpdate bool) DiscoveryV5Option {
+	return func(params *DiscV5Parameters) {
+		params.AutoUpdate = autoUpdate
+	}
+}
+
+// WithBootnodes is an option used to specify the bootstrap nodes to use with DiscV5
+func WithBootnodes(bootnodes []*enode.Node) DiscoveryV5Option {
+	return func(params *DiscV5Parameters) {
+		params.bootnodes = bootnodes
+	}
+}
+
+func WithAdvertiseAddr(addr []multiaddr.Multiaddr) DiscoveryV5Option {
+	return func(params *DiscV5Parameters) {
+		params.advertiseAddr = addr
+	}
+}
+
+func WithUDPPort(port uint) DiscoveryV5Option {
+	return func(params *DiscV5Parameters) {
+		params.UdpPort = port
+	}
+}
+
+func WithPredicate(predicate func(*enode.Node) bool) DiscoveryV5Option {
+	return func(params *DiscV5Parameters) {
+		params.loopPredicate = predicate
+	}
+}
+
+func WithAutoFindPeers(find bool) DiscoveryV5Option {
+	return func(params *DiscV5Parameters) {
+		params.autoFindPeers = find
+	}
+}
+
+func cliListToENode(logger *zap.Logger, slice cli.StringSlice) []*enode.Node {
+	var bootnodes []*enode.Node
+	for _, addr := range slice.Value() {
+		bootnode, err := enode.Parse(enode.ValidSchemes, addr)
+		if err != nil {
+			logger.Fatal("parsing ENR", zap.Error(err))
+		}
+		bootnodes = append(bootnodes, bootnode)
+	}
+	return bootnodes
+}
+
+func (params *DiscV5Parameters) Service(priv *ecdsa.PrivateKey, localnode *enode.LocalNode, peerConnector PeerConnector, reg prometheus.Registerer, log *zap.Logger, discoveredNodes []dnsdisc.DiscoveredNode, advertiseAddrs []multiaddr.Multiaddr) (*DiscoveryV5, error) {
+	if !params.enable {
+		return nil, nil
+	}
+	bootnodes := cliListToENode(log, params.clinodes)
+	for _, n := range discoveredNodes {
+		if n.ENR != nil {
+			bootnodes = append(bootnodes, n.ENR)
+		}
+	}
+	discV5Options := []DiscoveryV5Option{
+		WithBootnodes(params.bootnodes),
+		WithUDPPort(params.UdpPort),
+		WithAutoUpdate(params.AutoUpdate),
+		WithAdvertiseAddr(advertiseAddrs),
+		WithBootnodes(bootnodes),
+	}
+
+	return NewDiscoveryV5(priv, localnode, peerConnector, reg, log, discV5Options...)
+}

--- a/waku/v2/node/localnode.go
+++ b/waku/v2/node/localnode.go
@@ -263,7 +263,7 @@ func (w *WakuNode) setupENR(ctx context.Context, addrs []ma.Multiaddr) error {
 		return err
 	}
 
-	err = w.updateLocalNode(w.localNode, multiaddresses, ipAddr, w.opts.udpPort, w.wakuFlag, w.opts.advertiseAddrs, w.opts.discV5autoUpdate)
+	err = w.updateLocalNode(w.localNode, multiaddresses, ipAddr, w.opts.discv5Params.UdpPort, w.wakuFlag, w.opts.advertiseAddrs, w.opts.discv5Params.AutoUpdate)
 	if err != nil {
 		w.log.Error("updating localnode ENR record", zap.Error(err))
 		return err

--- a/waku/v2/node/wakunode2_test.go
+++ b/waku/v2/node/wakunode2_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/waku-org/go-waku/tests"
 	"github.com/waku-org/go-waku/waku/persistence"
 	"github.com/waku-org/go-waku/waku/persistence/sqlite"
+	"github.com/waku-org/go-waku/waku/v2/discv5"
 	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
 	"github.com/waku-org/go-waku/waku/v2/peerstore"
 	"github.com/waku-org/go-waku/waku/v2/protocol"
@@ -95,7 +96,7 @@ func TestUpAndDown(t *testing.T) {
 		WithPrivateKey(prvKey1),
 		WithHostAddress(hostAddr1),
 		WithWakuRelay(),
-		WithDiscoveryV5(0, bootnodes, true),
+		WithDiscoveryV5(discv5.GetDiscv5Params(0, bootnodes, true)),
 	)
 	require.NoError(t, err)
 

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/p2p/enode"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -26,6 +25,8 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/waku-org/go-waku/waku/v2/discv5"
+	"github.com/waku-org/go-waku/waku/v2/dnsdisc"
 	"github.com/waku-org/go-waku/waku/v2/protocol/filter"
 	"github.com/waku-org/go-waku/waku/v2/protocol/legacy_filter"
 	"github.com/waku-org/go-waku/waku/v2/protocol/pb"
@@ -90,10 +91,8 @@ type WakuNodeParameters struct {
 	maxPeerConnections int
 	peerStoreCapacity  int
 
-	enableDiscV5     bool
-	udpPort          uint
-	discV5bootnodes  []*enode.Node
-	discV5autoUpdate bool
+	discv5Params    discv5.DiscV5Parameters
+	discoveredNodes []dnsdisc.DiscoveredNode
 
 	enablePeerExchange bool
 
@@ -373,12 +372,15 @@ func WithPeerStoreCapacity(capacity int) WakuNodeOption {
 }
 
 // WithDiscoveryV5 is a WakuOption used to enable DiscV5 peer discovery
-func WithDiscoveryV5(udpPort uint, bootnodes []*enode.Node, autoUpdate bool) WakuNodeOption {
+func WithDiscoveryV5(discv5Params discv5.DiscV5Parameters) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
-		params.enableDiscV5 = true
-		params.udpPort = udpPort
-		params.discV5bootnodes = bootnodes
-		params.discV5autoUpdate = autoUpdate
+		params.discv5Params = discv5Params
+		return nil
+	}
+}
+func WithDiscoveredNodes(discoveredNodes []dnsdisc.DiscoveredNode) WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.discoveredNodes = discoveredNodes
 		return nil
 	}
 }

--- a/waku/v2/node/wakuoptions_test.go
+++ b/waku/v2/node/wakuoptions_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/waku-org/go-waku/tests"
 	"github.com/waku-org/go-waku/waku/persistence"
+	"github.com/waku-org/go-waku/waku/v2/discv5"
 	"github.com/waku-org/go-waku/waku/v2/protocol/store"
 )
 
@@ -40,7 +41,7 @@ func TestWakuOptions(t *testing.T) {
 		WithLibP2POptions(),
 		WithWakuRelay(),
 		WithLegacyWakuFilter(true),
-		WithDiscoveryV5(123, nil, false),
+		WithDiscoveryV5(discv5.GetDiscv5Params(123, nil, false)),
 		WithWakuStore(),
 		WithMessageProvider(&persistence.DBStore{}),
 		WithLightPush(),


### PR DESCRIPTION
# Description
Structure options/cli flags of discv5 in a single File. This will allow moving logic for creating discv5 to discv5 module. 
# Changes

- [x] discoveredNodes are set on `WakuNodeParameters` using `WithDiscoveredNOdes`, and this is then passed to Discv5.
- [x] Change type of discv5 in `WakuNode` from Service to `discv5.Discovery`. Reason golang a variable is nil if its type and value are both nil. `discv5Parameters.Service` returns nil of type `disv5.discovery` when service is not enabled. So, it is not equal to nil. And instance property of Service interface is not used for any purpose. I did this change. 
Another way to fix this is move service to common folder and change `discv5Parameters.Service` return type to Service.
- [x] Less context information for discv5 is needed outside discv5, like `disv5.enabled`. if discoveryv5 of WakuNode is nil, then the service is not being used. Currently `AutoUpdate` and `UdpPort` are exposed on `discoveryv5Params` as they are needed for localNode service. 

# Tests







<!--
## Issue

closes #
-->
