### PR TITLE
fix(lightpush): register lightpush protocol when instantiated

### DIFF
--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -53,6 +53,10 @@ func NewWakuLightPush(relay *relay.WakuRelay, pm *peermanager.PeerManager, reg p
 	wakuLP.pm = pm
 	wakuLP.metrics = newMetrics(reg)
 
+	if pm != nil {
+		wakuLP.pm.RegisterWakuProtocol(LightPushID_v20beta1, LightPushENRField)
+	}
+
 	return wakuLP
 }
 
@@ -73,9 +77,6 @@ func (wakuLP *WakuLightPush) Start(ctx context.Context) error {
 	wakuLP.h.SetStreamHandlerMatch(LightPushID_v20beta1, protocol.PrefixTextMatch(string(LightPushID_v20beta1)), wakuLP.onRequest(ctx))
 	wakuLP.log.Info("Light Push protocol started")
 
-	if wakuLP.pm != nil {
-		wakuLP.pm.RegisterWakuProtocol(LightPushID_v20beta1, LightPushENRField)
-	}
 	return nil
 }
 


### PR DESCRIPTION
Otherwise it is not possible to discover lightpush peers, as reported by @cammellos while testing shards.test on mobile:
```
ERROR[12-08|12:36:01.192|github.com/status-im/status-go/vendor/github.com/waku-org/go-waku/waku/v2/peermanager/peer_discovery.go:58]        cannot do on demand discovery for non-waku protocol protocol=/vac/waku/lightpush/2.0.0-beta1
```