### PR TITLE
fix: watchMultiaddressChanges

### DIFF
--- a/waku/v2/utils/multiaddr.go
+++ b/waku/v2/utils/multiaddr.go
@@ -17,15 +17,15 @@ func EncapsulatePeerID(peerID peer.ID, addrs ...multiaddr.Multiaddr) []multiaddr
 	return result
 }
 
-func MultiAddrSet(addr ...multiaddr.Multiaddr) map[multiaddr.Multiaddr]struct{} {
-	r := make(map[multiaddr.Multiaddr]struct{})
+func MultiAddrSet(addr ...multiaddr.Multiaddr) map[string]multiaddr.Multiaddr {
+	r := make(map[string]multiaddr.Multiaddr)
 	for _, a := range addr {
-		r[a] = struct{}{}
+		r[a.String()] = a
 	}
 	return r
 }
 
-func MultiAddrSetEquals(m1 map[multiaddr.Multiaddr]struct{}, m2 map[multiaddr.Multiaddr]struct{}) bool {
+func MultiAddrSetEquals(m1 map[string]multiaddr.Multiaddr, m2 map[string]multiaddr.Multiaddr) bool {
 	if len(m1) != len(m2) {
 		return false
 	}
@@ -40,10 +40,10 @@ func MultiAddrSetEquals(m1 map[multiaddr.Multiaddr]struct{}, m2 map[multiaddr.Mu
 	return true
 }
 
-func MultiAddrFromSet(m map[multiaddr.Multiaddr]struct{}) []multiaddr.Multiaddr {
+func MultiAddrFromSet(m map[string]multiaddr.Multiaddr) []multiaddr.Multiaddr {
 	var r []multiaddr.Multiaddr
-	for k := range m {
-		r = append(r, k)
+	for _, v := range m {
+		r = append(r, v)
 	}
 	return r
 }


### PR DESCRIPTION
There was a bad usage for map that use `multiaddr.Multiaddr` as key type, this result in `MultiAddrSetEquals` always return false. We have `watchMultiaddressChanges` and `discv5`, they both will update ENR concurrently which cause `TestPeerExchange` produce different result.

This PR will fix error "bad bootstrap node", [relate issue](https://github.com/status-im/status-go/issues/4835).

