### PR TITLE
fix: logout discover dead lock

### DIFF
--- a/waku/v2/service/common_discovery_service.go
+++ b/waku/v2/service/common_discovery_service.go
@@ -49,8 +49,6 @@ func (sp *CommonDiscoveryService) GetListeningChan() <-chan PeerData {
 	return sp.channel
 }
 func (sp *CommonDiscoveryService) PushToChan(data PeerData) bool {
-	sp.RLock()
-	defer sp.RUnlock()
 	if err := sp.ErrOnNotRunning(); err != nil {
 		return false
 	}


### PR DESCRIPTION
Pls see relate [issue](https://github.com/status-im/status-go/issues/4527) include comments as reference. This PR will fix the issue.

NOTE: creating a new goroutine for every call to PushToChan might introduce overhead, especially under high load. I'm not sure if we can use sync/atomic for simple state updates, or maybe redesigning the service to minimize shared state and reduce the need for locks. But I think this PR is a good start entry to discuss 🙂