### PR TITLE
feat: e2e rel poc - reconnection, new lamport Ts, logging

### DIFF
--- a/examples/chat2-reliable/chat_reliability_test.go
+++ b/examples/chat2-reliable/chat_reliability_test.go
@@ -141,7 +141,7 @@ func TestLamportTimestamps(t *testing.T) {
 		return true
 	}, 30*time.Second, 1*time.Second, "Message propagation failed")
 
-	assert.Equal(t, int32(1), env.chats[0].getLamportTimestamp(), "Sender's Lamport timestamp should be 1")
+	assert.Greater(t, env.chats[0].getLamportTimestamp(), int32(0), "Sender's Lamport timestamp should be greater than 0")
 	assert.Greater(t, env.chats[1].getLamportTimestamp(), int32(0), "Node 1's Lamport timestamp should be greater than 0")
 	assert.Greater(t, env.chats[2].getLamportTimestamp(), int32(0), "Node 2's Lamport timestamp should be greater than 0")
 


### PR DESCRIPTION
# Description
This PR add some updates to the e2e reliability POC based on the feedback from dogfooding

# Changes

- [x] new lamport timestamp that is hinted with a wall clock: clock = max(time.Now(), previous_clock+1)
- [x] disconnect and reconnect commands in chat to better simulate network instability conditions
- [x] better logging to effectively track causal history, missing messages etc