### PR TITLE
chore: fix store request id log

### DIFF
--- a/waku/v2/protocol/store/client.go
+++ b/waku/v2/protocol/store/client.go
@@ -263,7 +263,7 @@ func (s *WakuStore) next(ctx context.Context, r Result, opts ...RequestOption) (
 }
 
 func (s *WakuStore) queryFrom(ctx context.Context, storeRequest *pb.StoreQueryRequest, params *Parameters) (*pb.StoreQueryResponse, error) {
-	logger := s.log.With(logging.HostID("peer", params.selectedPeer), zap.String("requestId", hex.EncodeToString([]byte(storeRequest.RequestId))))
+	logger := s.log.With(logging.HostID("peer", params.selectedPeer), zap.String("requestId", storeRequest.RequestId))
 
 	logger.Debug("sending store request")
 


### PR DESCRIPTION
Fix log format error report by @Ivansete-status 

```
DEBUG[10-16|00:31:04.670|github.com/status-im/status-go/vendor/github.com/waku-org/go-waku/waku/v2/protocol/store/client.go:268]                   sending store request                
    peer=16Uiu2HAmCDSnT8oNpMR9HH6uipD71KstYuDCAQGpek9XDAVmqdEr requestId=386435316230353735323932346531303936666262643339346338356238663965636138383336353037386463333863626561333062316
13839323061613330
```

Use this code to get correct format before release. https://go.dev/play/p/1L2mA3BzEva