### PR TITLE
docs: update broken link

### DIFF
--- a/docs/tutorials/onchain-rln-relay-chat2.md
+++ b/docs/tutorials/onchain-rln-relay-chat2.md
@@ -137,7 +137,7 @@ You will see a different value than `165886530` on your screen.
 If two messages sent by the same chat2 client happen to have the same RLN epoch value, then one of them will be detected as spam and won't be routed (by test fleets in this test setting).
 You'll also see a `ERROR: validation failed` message
 At the time of this tutorial, the epoch duration is set to `10` seconds.
-You can inspect the current epoch value by checking the following [constant variable](https://github.com/waku-org/go-zerokit-rln/blob/main/rln/types.go#L194) in the go-rln codebase.
+You can inspect the current epoch value by checking the following [constant variable](https://github.com/waku-org/go-zerokit-rln/blob/master/rln/types.go#L195) in the go-rln codebase.
 Thus, if you send two messages less than `10` seconds apart, they are likely to get the same `rln epoch` values.
 
 After sending a chat message, you may experience some delay before the next chat prompt appears. 


### PR DESCRIPTION
# Description
Hi! I fixed a broken link. The previous link pointed to an outdated branch and line number.