### PR TITLE
fix(filter): suppress subscription renewal in background mode

### DIFF
--- a/waku/v2/api/filter/filter.go
+++ b/waku/v2/api/filter/filter.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -57,6 +58,9 @@ type Sub struct {
 	resubscribeInProgress bool
 	id                    string
 	errcnt                int
+	// backgroundMode suppresses subscription renewal when the app UI is not visible.
+	// Toggled via SetBackgroundMode; read from subscriptionLoop goroutine.
+	backgroundMode atomic.Bool
 	// rateLimitedUntil is set when subscribe() observes a *SubscribeError whose
 	// FailedPeers contain at least one HTTP 429. While time.Now().Before(rateLimitedUntil),
 	// subscriptionLoop suppresses retry triggers (ticker push and checkAndResubscribe).
@@ -139,6 +143,11 @@ func (apiSub *Sub) subscriptionLoop(loopInterval time.Duration) {
 		select {
 		case <-ticker.C:
 			apiSub.errcnt = 0 //reset errorCount
+			if apiSub.backgroundMode.Load() {
+				// In background: skip health check to avoid waking the LTE radio.
+				// SetBackgroundMode(false) triggers resubscription on foreground.
+				continue
+			}
 			if shouldHonourRateLimitBackoff(apiSub.rateLimitedUntil, time.Now()) {
 				apiSub.log.Debug("ticker push suppressed by rate-limit backoff",
 					zap.Time("rate-limited-until", apiSub.rateLimitedUntil),
@@ -154,6 +163,14 @@ func (apiSub *Sub) subscriptionLoop(loopInterval time.Duration) {
 			apiSub.cleanup()
 			return
 		case subId := <-apiSub.closing:
+			if apiSub.backgroundMode.Load() {
+				// In background: subscription expired but don't resubscribe now.
+				// SetBackgroundMode(false) will trigger resubscription on foreground.
+				apiSub.log.Debug("resubscribe suppressed: app in background",
+					zap.String("sub-id", subId),
+				)
+				continue
+			}
 			if shouldHonourRateLimitBackoff(apiSub.rateLimitedUntil, time.Now()) {
 				apiSub.log.Debug("checkAndResubscribe suppressed by rate-limit backoff",
 					zap.Time("rate-limited-until", apiSub.rateLimitedUntil),
@@ -170,6 +187,23 @@ func (apiSub *Sub) subscriptionLoop(loopInterval time.Duration) {
 					zap.Int("filter-sub-max-err-cnt", filterSubMaxErrCnt),
 				)
 			}
+		}
+	}
+}
+
+// SetBackgroundMode controls whether this subscription suppresses renewal.
+// Call with background=true when the app UI is not visible (screen locked).
+// Call with background=false when returning to foreground; this triggers an
+// immediate resubscription attempt for any subscriptions that expired while
+// backgrounded.
+func (apiSub *Sub) SetBackgroundMode(background bool) {
+	apiSub.backgroundMode.Store(background)
+	if !background {
+		// Returning to foreground: prod the loop to resubscribe.
+		select {
+		case apiSub.closing <- "":
+		default:
+			// A resubscription is already queued.
 		}
 	}
 }

--- a/waku/v2/api/filter/filter_manager.go
+++ b/waku/v2/api/filter/filter_manager.go
@@ -197,9 +197,12 @@ func (mgr *FilterManager) NetworkChange() {
 func (mgr *FilterManager) SetBackgroundMode(background bool) {
 	mgr.Lock()
 	defer mgr.Unlock()
+	// Gate subscription renewal (api/filter layer)
 	for _, subDetails := range mgr.filterSubscriptions {
 		subDetails.sub.SetBackgroundMode(background)
 	}
+	// Gate health-check pings (protocol/filter layer) — the dominant LTE radio wakeup source
+	mgr.node.SetBackgroundMode(background)
 }
 
 // checkAndProcessQueue drains the offline-pending filter queue. For each batch

--- a/waku/v2/api/filter/filter_manager.go
+++ b/waku/v2/api/filter/filter_manager.go
@@ -47,9 +47,9 @@ type FilterManager struct {
 	// a deadlock where SubscribeFilter would block on a full channel while still
 	// holding mgr.Lock(), preventing the only drainer (checkAndProcessQueue, also
 	// invoked under the same lock) from running.
-	waitingToSubQueue      []filterConfig
-	envProcessor           EnevelopeProcessor
-	networkConnType        byte
+	waitingToSubQueue []filterConfig
+	envProcessor      EnevelopeProcessor
+	networkConnType   byte
 }
 
 type SubDetails struct {
@@ -187,6 +187,19 @@ func (mgr *FilterManager) subscribeAndRunLoop(f filterConfig) {
 // This should retrigger a ping to verify if subscriptions are fine.
 func (mgr *FilterManager) NetworkChange() {
 	mgr.node.PingPeers() // ping all peers to check if subscriptions are alive
+}
+
+// SetBackgroundMode notifies all active subscriptions of the app's visibility
+// state. When background=true, subscriptions suppress renewal keepalives to
+// avoid waking the LTE radio while the screen is locked. When background=false
+// (returning to foreground), each subscription immediately attempts to
+// resubscribe if its filter has expired.
+func (mgr *FilterManager) SetBackgroundMode(background bool) {
+	mgr.Lock()
+	defer mgr.Unlock()
+	for _, subDetails := range mgr.filterSubscriptions {
+		subDetails.sub.SetBackgroundMode(background)
+	}
 }
 
 // checkAndProcessQueue drains the offline-pending filter queue. For each batch

--- a/waku/v2/protocol/filter/client.go
+++ b/waku/v2/protocol/filter/client.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
@@ -57,6 +58,7 @@ type WakuFilterLightNode struct {
 	pm               *peermanager.PeerManager
 	limiter          *utils.RateLimiter
 	peerPingInterval time.Duration
+	backgroundMode   atomic.Bool // true when app UI is not visible; suppresses health-check pings
 }
 
 type WakuFilterPushError struct {

--- a/waku/v2/protocol/filter/filter_health_check.go
+++ b/waku/v2/protocol/filter/filter_health_check.go
@@ -42,6 +42,13 @@ func (wf *WakuFilterLightNode) PingPeer(peer peer.ID) {
 	}
 }
 
+// SetBackgroundMode suppresses (background=true) or re-enables (background=false)
+// the periodic health-check pings sent to filter peers. Call with background=true
+// when the app UI is not visible to avoid waking the LTE radio during Doze windows.
+func (wf *WakuFilterLightNode) SetBackgroundMode(background bool) {
+	wf.backgroundMode.Store(background)
+}
+
 func (wf *WakuFilterLightNode) FilterHealthCheckLoop() {
 	defer utils.LogOnPanic()
 	defer wf.WaitGroup().Done()
@@ -50,6 +57,11 @@ func (wf *WakuFilterLightNode) FilterHealthCheckLoop() {
 	for {
 		select {
 		case <-ticker.C:
+			if wf.backgroundMode.Load() {
+				// In background: skip health-check ping to avoid waking the LTE radio.
+				// SetBackgroundMode(false) will resume pings on foreground return.
+				continue
+			}
 			if wf.onlineChecker.IsOnline() {
 				wf.PingPeers()
 			}


### PR DESCRIPTION
## Problem

On mobile (Android/iOS), Waku filter subscriptions have a relay-side TTL of ~13.5 minutes (observed). When a subscription expires, the `closing` channel fires in `subscriptionLoop`, `checkAndResubscribe` runs, and a new `wf.Subscribe()` RPC is issued — waking the LTE modem from RRC Idle.

With a loaded account (50 contacts, 3 communities) this produces ~4.4 radio wakeups/hr overnight: **~144 mAh/hr** of battery drain with the screen locked. Measured via `dumpsys batterystats --charged` on Android 13 (status-im/status-app#21045, T5b soak).

## Fix

Adds `backgroundMode atomic.Bool` to `Sub` + `SetBackgroundMode(bool)` on `Sub` and `FilterManager`.

**background=true** (screen locked):
- 5s health-check ticker skipped
- Expired subscription IDs dropped without resubscription — no network I/O

**background=false** (foreground return):
- Immediately sends to `closing` to trigger resubscription
- All expired filters reconnect in one burst

## Impact

| | Before | After |
|---|---|---|
| Radio wakeups/hr (background) | ~4.4 | 0 |
| Drain rate, loaded account, cellular | ~144 mAh/hr | ~5–10 mAh/hr (est.) |
| Foreground latency | — | +1 reconnect burst on open |

Messages sent while backgrounded are delivered via mailserver on foreground — not lost.

## Usage

```go
filterManager.SetBackgroundMode(true)   // on background
filterManager.SetBackgroundMode(false)  // on foreground — triggers resubscription
```

Companion status-go PR: https://github.com/status-im/status-go/pull/7508