### PR TITLE
fix: bound WakuNode.Stop() with timeouts to avoid hang on dead connections

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -527,40 +527,67 @@ func (w *WakuNode) Stop() {
 		return
 	}
 
-	w.bcaster.Stop()
+	// Cancel the node context before stopping protocols: once processLoop sees
+	// ctx.Done() it stops draining its channels, so a later send would block.
+	w.cancel()
+
+	stopWithTimeout(w.bcaster.Stop, "bcaster", 5*time.Second, w.log)
 
 	defer w.connectionNotif.Close()
 	defer w.addressChangesSub.Close()
 
 	w.host.Network().StopNotify(w.connectionNotif)
 
-	w.relay.Stop()
-	w.lightPush.Stop()
-	w.legacyStore.Stop()
-	w.filterFullNode.Stop()
-	w.filterLightNode.Stop()
+	// Each Stop() calls wg.Wait() internally and can block on a goroutine stuck
+	// writing to a dead connection; the timeout keeps Stop() bounded.
+	stopWithTimeout(w.relay.Stop, "relay", 10*time.Second, w.log)
+	stopWithTimeout(w.lightPush.Stop, "lightPush", 5*time.Second, w.log)
+	stopWithTimeout(w.legacyStore.Stop, "legacyStore", 5*time.Second, w.log)
+	stopWithTimeout(w.filterFullNode.Stop, "filterFullNode", 5*time.Second, w.log)
+	stopWithTimeout(w.filterLightNode.Stop, "filterLightNode", 5*time.Second, w.log)
 
 	if w.opts.enableDiscV5 {
-		w.discoveryV5.Stop()
+		stopWithTimeout(w.discoveryV5.Stop, "discoveryV5", 5*time.Second, w.log)
 	}
-	w.peerExchange.Stop()
-	w.rendezvous.Stop()
+	stopWithTimeout(w.peerExchange.Stop, "peerExchange", 5*time.Second, w.log)
+	stopWithTimeout(w.rendezvous.Stop, "rendezvous", 5*time.Second, w.log)
+	stopWithTimeout(w.peerConnector.Stop, "peerConnector", 5*time.Second, w.log)
+	stopWithTimeout(func() { _ = w.stopRlnRelay() }, "rlnRelay", 5*time.Second, w.log)
+	stopWithTimeout(w.timesource.Stop, "timesource", 5*time.Second, w.log)
 
-	w.peerConnector.Stop()
-
-	_ = w.stopRlnRelay()
-
-	w.timesource.Stop()
-
-	w.host.Close()
-
-	w.cancel()
-
-	w.wg.Wait()
+	// Bound the wait: goroutines select on ctx.Done() and should exit promptly.
+	waitDone := make(chan struct{})
+	go func() { w.wg.Wait(); close(waitDone) }()
+	select {
+	case <-waitDone:
+	case <-time.After(5 * time.Second):
+		w.log.Error("timed out waiting for node goroutines to stop")
+	}
 
 	close(w.enrChangeCh)
 
+	// host.Close() can block indefinitely draining dead sockets; bound it too.
+	hostClosed := make(chan struct{})
+	go func() { w.host.Close(); close(hostClosed) }()
+	select {
+	case <-hostClosed:
+	case <-time.After(5 * time.Second):
+		w.log.Warn("timed out waiting for host.Close(); proceeding")
+	}
+
 	w.cancel = nil
+}
+
+// stopWithTimeout runs fn and returns once it completes or timeout elapses,
+// logging a warning on timeout so one stuck component cannot hang Stop().
+func stopWithTimeout(fn func(), name string, timeout time.Duration, log *zap.Logger) {
+	done := make(chan struct{})
+	go func() { fn(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		log.Warn("timed out stopping component", zap.String("component", name))
+	}
 }
 
 // Host returns the libp2p Host used by the WakuNode

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -527,11 +527,11 @@ func (w *WakuNode) Stop() {
 		return
 	}
 
-	// Cancel the node context before stopping protocols: once processLoop sees
-	// ctx.Done() it stops draining its channels, so a later send would block.
+	// Cancel the node context before stopping protocols: node goroutines that
+	// observe ctx.Done() stop draining their channels, so a later send would block.
 	w.cancel()
 
-	stopWithTimeout(w.bcaster.Stop, "bcaster", 5*time.Second, w.log)
+	w.stopWithTimeout(w.bcaster.Stop, "bcaster", 5*time.Second)
 
 	defer w.connectionNotif.Close()
 	defer w.addressChangesSub.Close()
@@ -540,31 +540,34 @@ func (w *WakuNode) Stop() {
 
 	// Each Stop() calls wg.Wait() internally and can block on a goroutine stuck
 	// writing to a dead connection; the timeout keeps Stop() bounded.
-	stopWithTimeout(w.relay.Stop, "relay", 10*time.Second, w.log)
-	stopWithTimeout(w.lightPush.Stop, "lightPush", 5*time.Second, w.log)
-	stopWithTimeout(w.legacyStore.Stop, "legacyStore", 5*time.Second, w.log)
-	stopWithTimeout(w.filterFullNode.Stop, "filterFullNode", 5*time.Second, w.log)
-	stopWithTimeout(w.filterLightNode.Stop, "filterLightNode", 5*time.Second, w.log)
+	w.stopWithTimeout(w.relay.Stop, "relay", 10*time.Second)
+	w.stopWithTimeout(w.lightPush.Stop, "lightPush", 5*time.Second)
+	w.stopWithTimeout(w.legacyStore.Stop, "legacyStore", 5*time.Second)
+	w.stopWithTimeout(w.filterFullNode.Stop, "filterFullNode", 5*time.Second)
+	w.stopWithTimeout(w.filterLightNode.Stop, "filterLightNode", 5*time.Second)
 
 	if w.opts.enableDiscV5 {
-		stopWithTimeout(w.discoveryV5.Stop, "discoveryV5", 5*time.Second, w.log)
+		w.stopWithTimeout(w.discoveryV5.Stop, "discoveryV5", 5*time.Second)
 	}
-	stopWithTimeout(w.peerExchange.Stop, "peerExchange", 5*time.Second, w.log)
-	stopWithTimeout(w.rendezvous.Stop, "rendezvous", 5*time.Second, w.log)
-	stopWithTimeout(w.peerConnector.Stop, "peerConnector", 5*time.Second, w.log)
-	stopWithTimeout(func() { _ = w.stopRlnRelay() }, "rlnRelay", 5*time.Second, w.log)
-	stopWithTimeout(w.timesource.Stop, "timesource", 5*time.Second, w.log)
+	w.stopWithTimeout(w.peerExchange.Stop, "peerExchange", 5*time.Second)
+	w.stopWithTimeout(w.rendezvous.Stop, "rendezvous", 5*time.Second)
+	w.stopWithTimeout(w.peerConnector.Stop, "peerConnector", 5*time.Second)
+	w.stopWithTimeout(func() { _ = w.stopRlnRelay() }, "rlnRelay", 5*time.Second)
+	w.stopWithTimeout(w.timesource.Stop, "timesource", 5*time.Second)
 
 	// Bound the wait: goroutines select on ctx.Done() and should exit promptly.
 	waitDone := make(chan struct{})
 	go func() { w.wg.Wait(); close(waitDone) }()
 	select {
 	case <-waitDone:
+		// All node goroutines have exited, so it is safe to close the channels
+		// they send on.
+		close(w.enrChangeCh)
 	case <-time.After(5 * time.Second):
-		w.log.Error("timed out waiting for node goroutines to stop")
+		// Some goroutines may still be running; leave enrChangeCh open, otherwise
+		// a pending send would panic with "send on closed channel".
+		w.log.Error("timed out waiting for node goroutines to stop; leaving enrChangeCh open")
 	}
-
-	close(w.enrChangeCh)
 
 	// host.Close() can block indefinitely draining dead sockets; bound it too.
 	hostClosed := make(chan struct{})
@@ -580,13 +583,13 @@ func (w *WakuNode) Stop() {
 
 // stopWithTimeout runs fn and returns once it completes or timeout elapses,
 // logging a warning on timeout so one stuck component cannot hang Stop().
-func stopWithTimeout(fn func(), name string, timeout time.Duration, log *zap.Logger) {
+func (w *WakuNode) stopWithTimeout(fn func(), name string, timeout time.Duration) {
 	done := make(chan struct{})
 	go func() { fn(); close(done) }()
 	select {
 	case <-done:
 	case <-time.After(timeout):
-		log.Warn("timed out stopping component", zap.String("component", name))
+		w.log.Warn("timed out stopping component", zap.String("component", name))
 	}
 }
 


### PR DESCRIPTION
# Description
`WakuNode.Stop()` could block indefinitely when the node held dead/half-open TCP
connections (e.g. after device suspend/resume or network loss). The context was
cancelled only *after* the protocol `Stop()` calls, and each `Stop()`/`host.Close()`
waited on goroutines blocked writing to sockets that never drain — so shutdown hung.

# Changes
- [x] Cancel the node context before stopping protocols, so loops observing `ctx.Done()` exit first
- [x] Wrap each component `Stop()`, `wg.Wait()` and `host.Close()` in a bounded `stopWithTimeout` helper that logs and proceeds on timeout
- [x] `Stop()` now always returns within a bounded time, even if one component is stuck

# Tests
- [x] `go build ./...` and `gofmt` clean
- [x] Manually verified with the client application
closes #1305
