### PR TITLE
fix: reset peer backoff on recovery so reconnect is not blocked

### DIFF
--- a/waku/v2/node/keepalive.go
+++ b/waku/v2/node/keepalive.go
@@ -90,11 +90,13 @@ func (w *WakuNode) startKeepAlive(ctx context.Context, randomPeersPingDuration t
 				lastTimeExecuted = w.timesource.Now()
 				w.log.Warn("keep alive hasnt been executed recently. Killing all connections")
 				disconnectAllPeers(w.host, w.log)
+				w.peerConnector.ResetBackoff()
 				continue
 			} else if iterationFailure >= maxAllowedSubsequentPingFailures {
 				iterationFailure = 0
 				w.log.Warn("Pinging random peers failed, node is likely disconnected. Killing all connections")
 				disconnectAllPeers(w.host, w.log)
+				w.peerConnector.ResetBackoff()
 				continue
 			}
 

--- a/waku/v2/peermanager/peer_connector.go
+++ b/waku/v2/peermanager/peer_connector.go
@@ -218,6 +218,16 @@ func (c *PeerConnectionStrategy) canDialPeer(pi peer.AddrInfo) bool {
 	return true
 }
 
+// ResetBackoff clears all accumulated per-peer connection backoffs so that
+// every known peer can be retried immediately on the next connection attempt.
+// Call this after a recovery event (e.g. sleep/wake, all pings failed) so that
+// stale hour-long backoffs do not prevent reconnection once the network is back.
+func (c *PeerConnectionStrategy) ResetBackoff() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+	c.cache.Purge()
+}
+
 func (c *PeerConnectionStrategy) addConnectionBackoff(peerID peer.ID) {
 	c.mux.Lock()
 	defer c.mux.Unlock()


### PR DESCRIPTION
# Description
When keep-alive detects the node is disconnected (no recent keep-alive, or N subsequent
ping failures) it disconnects all peers to force a fresh start. But `PeerConnectionStrategy`
still holds each peer's accumulated backoff, so the connector skips those peers until the
backoff — which can grow to ~1h — expires, leaving the node disconnected. This adds
`ResetBackoff()` and calls it on the recovery paths so every known peer can be redialed
immediately once the network is back.

# Changes
- [x] Add `PeerConnectionStrategy.ResetBackoff()` to purge the per-peer backoff cache
- [x] Call it in `startKeepAlive` after `disconnectAllPeers` on both recovery branches

# Tests
- [x] `go build ./...` and `gofmt` clean
- [ ] Manually verified peers are redialed immediately after a forced full disconnect
- [x] Manually test the client app reconnects to peers after a recovery event

## Issue

closes #1307 
