### PR TITLE
fix(peermanager): prefer connected peers in selection

### DIFF
--- a/waku/v2/peermanager/peer_selection.go
+++ b/waku/v2/peermanager/peer_selection.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"go.uber.org/zap"
@@ -91,6 +92,10 @@ func (pm *PeerManager) SelectRandom(criteria PeerSelectionCriteria) (peer.IDSlic
 		filteredPeers = pm.host.Peerstore().(wps.WakuPeerstore).PeersByPubSubTopics(criteria.PubsubTopics, filteredPeers...)
 	}
 
+	// Prefer peers we are already connected to, so we don't churn on dialing
+	// stale/unreachable peers learned via discovery or peer-exchange.
+	filteredPeers = pm.preferConnectedPeers(filteredPeers)
+
 	//Not passing excludePeers as filterPeers are already considering excluded ones.
 	randomPeers, err := selectRandomPeers(filteredPeers, nil, min(criteria.MaxPeers, len(peerIDs)))
 	if err != nil && len(peerIDs) == 0 {
@@ -119,6 +124,28 @@ func getRandom(filter PeerSet, count int, excludePeers PeerSet) (PeerSet, error)
 		return nil, utils.ErrNoPeersAvailable
 	}
 	return selectedPeers, nil
+}
+
+// preferConnectedPeers returns the subset of the given peers that we are
+// currently connected to. If none are connected it returns the input unchanged.
+//
+// This biases peer selection toward reachable peers (e.g. an already-connected
+// fleet/service node) instead of stale or unreachable peers learned via
+// discv5/peer-exchange. Without this, selection is connectedness-blind and a
+// light node can repeatedly pick dead peers for filter/lightpush, churning on
+// failed dials and missing messages while a perfectly good connected peer is
+// available (see status-im/status-go#7513).
+func (pm *PeerManager) preferConnectedPeers(peers peer.IDSlice) peer.IDSlice {
+	connected := make(peer.IDSlice, 0, len(peers))
+	for _, p := range peers {
+		if pm.host.Network().Connectedness(p) == network.Connected {
+			connected = append(connected, p)
+		}
+	}
+	if len(connected) > 0 {
+		return connected
+	}
+	return peers
 }
 
 // selects count random peers from list of peers
@@ -172,6 +199,8 @@ func (pm *PeerManager) selectServicePeer(criteria PeerSelectionCriteria) (PeerSe
 		}
 		slot.mu.RUnlock()
 		selectedPeers := pm.host.Peerstore().(wps.WakuPeerstore).PeersByPubSubTopics(criteria.PubsubTopics, keys...)
+		// Prefer already-connected service peers over stale/unreachable ones.
+		selectedPeers = pm.preferConnectedPeers(selectedPeers)
 		tmpPeers, err := selectRandomPeers(selectedPeers, criteria.ExcludePeers, criteria.MaxPeers)
 		for tmpPeer := range tmpPeers {
 			peers[tmpPeer] = struct{}{}


### PR DESCRIPTION
## Problem

Filter/lightpush peer selection (`Automatic` → `SelectRandom`, and the
service-slot pubsub-topic path in `selectServicePeer`) picks uniformly at
random among **all** peers that support the protocol + pubsub topic, with no
regard for connectedness.

A light node that has learned many peers via discv5 / peer-exchange — some of
them stale or unreachable (e.g. torn-down nodes whose ENRs a bootstrap node is
still advertising) — therefore keeps selecting dead peers for its filter
subscriptions. It churns on failed dials (`all dials failed`) and the
subscription for a content topic can stay down long enough to miss messages,
**even while an already-connected, reachable service node is available**.

This is the proximate cause of the flaky status-go light-client functional
tests (status-im/status-go#7513): in CI a failing light node was observed
re-dialing ~18 dead peer-exchange peers 30–70× each over 70s while a perfectly
good connected fleet node sat unused.

## Change

Add `preferConnectedPeers`: bias selection toward peers we are currently
connected to, **falling back to the full candidate set when none are
connected** (so behavior is unchanged when there is no connected candidate).
Applied in both `SelectRandom` and the `selectServicePeer` pubsub-topic path.

## Notes

- Backward-compatible: existing `peermanager` selection tests pass unchanged
  (they don't connect the candidate peers, so the fallback returns the full
  set as before).
- A connected-preference unit test that actually dials a peer is awkward here
  because libp2p `identify` overwrites the manually-added supported protocols
  after connection (the existing `SelectPeerWithLowestRTT` test is ordered last
  for the same reason); happy to add one if you have a preferred harness.
- Complements the nwaku-side fix logos-messaging/logos-delivery#3939 (stop the
  bootstrap node from serving stale ENRs); this PR makes the client resilient
  regardless of what it is served.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
