### PR TITLE
fix(filter): correct inverted idle-subscription cleanup check

### DIFF
--- a/waku/v2/protocol/filter/subscribers_map.go
+++ b/waku/v2/protocol/filter/subscribers_map.go
@@ -250,7 +250,7 @@ func (sub *SubscribersMap) cleanUp(ctx context.Context, cleanupInterval time.Dur
 			sub.Lock()
 			for peerID, lastSeen := range sub.lastSeen {
 				elapsedTime := time.Since(lastSeen)
-				if elapsedTime < sub.timeout {
+				if elapsedTime > sub.timeout {
 					_ = sub.deleteAll(peerID)
 				}
 

--- a/waku/v2/protocol/filter/subscribers_map_test.go
+++ b/waku/v2/protocol/filter/subscribers_map_test.go
@@ -107,13 +107,15 @@ func TestRemoveBogus(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestCleanup verifies that a subscriber which has not been refreshed within
+// the idle timeout is removed by the periodic cleanup.
 func TestCleanup(t *testing.T) {
-	subs := NewSubscribersMap(2 * time.Second)
+	subs := NewSubscribersMap(1 * time.Second)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	go subs.cleanUp(ctx, 500*time.Millisecond)
+	go subs.cleanUp(ctx, 100*time.Millisecond)
 
 	peerId := createPeerID(t)
 
@@ -125,11 +127,43 @@ func TestCleanup(t *testing.T) {
 	_, exists := subs.Get(peerId)
 	require.True(t, exists)
 
-	time.Sleep(2 * time.Second)
+	// Let the subscriber go idle past the timeout; it must be cleaned up.
+	time.Sleep(1500 * time.Millisecond)
 
 	hasSubs = subs.Has(peerId)
 	require.False(t, hasSubs)
 
 	_, exists = subs.Get(peerId)
 	require.False(t, exists)
+}
+
+// TestCleanupKeepsActiveSubscribers verifies that a subscriber which keeps
+// getting refreshed (e.g. via pings) survives the periodic cleanup, and is
+// only removed once it goes idle past the timeout. This guards against a
+// regression where the idle check was inverted and active subscribers were
+// deleted while idle ones were kept forever.
+func TestCleanupKeepsActiveSubscribers(t *testing.T) {
+	timeout := 1 * time.Second
+	subs := NewSubscribersMap(timeout)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go subs.cleanUp(ctx, 100*time.Millisecond)
+
+	peerId := createPeerID(t)
+	subs.Set(peerId, PUBSUB_TOPIC, []string{"topic1", "topic2"})
+
+	// Keep the subscriber active for well over the timeout by refreshing it
+	// periodically. It must never be cleaned up while active.
+	for i := 0; i < 15; i++ {
+		time.Sleep(100 * time.Millisecond)
+		subs.Refresh(peerId)
+		require.True(t, subs.Has(peerId), "active subscriber was removed while being refreshed")
+	}
+
+	// Stop refreshing; once idle past the timeout it must be removed.
+	require.Eventually(t, func() bool {
+		return !subs.Has(peerId)
+	}, 3*time.Second, 100*time.Millisecond, "idle subscriber was not cleaned up")
 }


### PR DESCRIPTION
## Summary

QA reported suspicious logic in `waku/v2/protocol/filter/subscribers_map.go`. This confirms it as a **real bug** and fixes it.

The periodic cleanup that reaps idle filter subscriptions had its comparison **inverted**:

```go
elapsedTime := time.Since(lastSeen)
if elapsedTime < sub.timeout {   // BUG: was `<`, should be `>`
    _ = sub.deleteAll(peerID)
}
```

### Why it's wrong

- `timeout` is the idle-subscription timeout (`DefaultIdleSubscriptionTimeout = 5m`).
- A subscribed client keeps its subscription alive by pinging; each ping calls `Refresh`, updating `lastSeen`.
- `elapsedTime` is therefore *how long since the peer was last active*.

The intent is to drop subscriptions that have gone **idle** (`elapsedTime > timeout`). The old code did the opposite: it deleted **recently-active** subscribers (elapsed `<` timeout, dropped within one ≤1-minute cleanup cycle) and **never reaped truly idle ones** (they leaked forever).

### Impact

- Filter full/service nodes (`WakuFilterFullNode`) silently dropped healthy subscribers that were correctly keeping their subscriptions alive, causing intermittent filter message-delivery loss until clients re-subscribed.
- Idle/dead subscriptions were never cleaned up, leaking the subscribers map.
- Light clients are unaffected.

## Fix

Flip the comparison to `>` so a subscriber is removed only once it has been idle longer than the timeout.

## Tests

- **Rewrote `TestCleanup`** — it previously passed *because of* the bug (an unrefreshed subscriber set at t=0 was deleted at the first cleanup tick regardless of direction). It now uses timings that assert genuine idle-based removal.
- **Added `TestCleanupKeepsActiveSubscribers`** — keeps a subscriber active via periodic `Refresh` and asserts it survives well past the timeout, then that it is removed once idle. This test **fails on the old inverted check** (active subscriber deleted at the first tick, ~0.1s) and passes with the fix.

Verified locally: both tests pass with the fix; `TestCleanupKeepsActiveSubscribers` fails when the comparison is reverted to `<`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)