### PR TITLE
fix(build): fix Android library builds on Go 1.23+ and non-Linux hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,15 @@ else
  GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS="-Wl,-soname,libgowaku.so.0"
 endif
 
+# Cross-compiling for Android always produces an ELF .so, whatever the build
+# host is, so the host detection above would pick the wrong extension on macOS
+# and Windows. Android also cannot load a versioned soname: the APK only ships
+# lib*.so and its linker has no version support, so use a plain libgowaku.so.
+ifeq ($(GOOS),android)
+GOBIN_SHARED_LIB_EXT := so
+GOBIN_SHARED_LIB_CGO_LDFLAGS := CGO_LDFLAGS="-Wl,-soname,libgowaku.so"
+endif
+
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 VERSION = $(shell cat ./VERSION)
 UID := $(shell id -u)
@@ -37,6 +46,22 @@ BUILD_FLAGS ?= $(shell echo "-ldflags='\
 	-X github.com/waku-org/go-waku/waku/v2/node.Version=$(VERSION)'")
 
 ANDROID_TARGET ?= 23
+
+# Extra Go linker flags for the c-archive / c-shared library builds:
+#   -checklinkname=0  needed on Android: the indirect dependency
+#                     github.com/wlynxg/anet uses //go:linkname in
+#                     interface_android.go, which Go 1.23+ rejects by default.
+#   -s                omit the symbol table
+#   -w                omit the DWARF debug information
+# -s -w are applied only for BUILD_TYPE=release, where they noticeably reduce the
+# size of the resulting library; other build types keep the symbols for debugging.
+GO_LDFLAGS_EXTRA :=
+ifeq ($(GOOS),android)
+GO_LDFLAGS_EXTRA += -checklinkname=0
+endif
+ifeq ($(BUILD_TYPE),release)
+GO_LDFLAGS_EXTRA += -s -w
+endif
 
 # control rln code compilation
 ifeq ($(NO_RLN), true)
@@ -125,6 +150,7 @@ static-library:
 	@echo "Building static library..."
 	"${GOCMD}" build \
 		-buildmode=c-archive \
+		-ldflags="$(GO_LDFLAGS_EXTRA)" \
 		-tags="${BUILD_TAGS} gowaku_no_rln" \
 		-o ./build/lib/libgowaku.a \
 		./library/c/
@@ -141,6 +167,7 @@ dynamic-library:
 	rm -f ./build/lib/libgowaku.$(GOBIN_SHARED_LIB_EXT)*
 	$(GOBIN_SHARED_LIB_CFLAGS) $(GOBIN_SHARED_LIB_CGO_LDFLAGS) "${GOCMD}" build \
 		-buildmode=c-shared \
+		-ldflags="$(GO_LDFLAGS_EXTRA)" \
 		-tags="${BUILD_TAGS} gowaku_no_rln" \
 		-o ./build/lib/libgowaku.$(GOBIN_SHARED_LIB_EXT) \
 		./library/c/
@@ -150,9 +177,11 @@ else
 	sed -i "s/#include <cgo_utils.h>//gi" ./build/lib/libgowaku.h
 endif
 ifeq ($(detected_OS),Linux)
+ifneq ($(GOOS),android)
 	cd ./build/lib && \
 	mv ./libgowaku.$(GOBIN_SHARED_LIB_EXT) ./libgowaku.$(GOBIN_SHARED_LIB_EXT).0 && \
 	ln -s ./libgowaku.$(GOBIN_SHARED_LIB_EXT).0 ./libgowaku.$(GOBIN_SHARED_LIB_EXT)
+endif
 endif
 	@echo "Shared library built:"
 	@ls -la ./build/lib/libgowaku.*


### PR DESCRIPTION
# Description
Building the go-waku C libraries for Android currently fails in two ways, and
release artifacts are larger than they need to be:

1. **Go 1.23+ rejects the build.** The indirect dependency `github.com/wlynxg/anet`
   (pulled in via go-libp2p) uses `//go:linkname` in `interface_android.go`, which
   Go 1.23 disallows by default. That file is Android-only, so CI on Linux/macOS
   never compiles it — but every Android build of the C libraries hits it.

2. **Cross-compiling from a non-Linux host produces the wrong artifact.** The
   shared-library extension and soname are selected from `detected_OS` (the *build
   host*), not the target. Building for Android on macOS/Windows therefore yields
   `libgowaku.dylib` / `libgowaku.dll` with no soname, instead of an ELF
   `libgowaku.so`.

3. **Release builds keep debug data they don't need.** The library targets pass no
   linker flags, so the symbol table and DWARF info are retained even in release
   artifacts — roughly 10 MB of dead weight in a shipped application. `-s -w` is
   applied only for `BUILD_TYPE=release`, so releases shrink while other build
   types keep their symbols. The default is unchanged.

Android also cannot load a versioned soname — an APK only ships `lib*.so`, symlinks
do not survive APK packaging, and bionic has no soname versioning — so the Android
`.so` stays unversioned and skips the `.so.0` rename/symlink that desktop Linux uses.

# Changes
- [x] Force `GOBIN_SHARED_LIB_EXT := so` and an unversioned soname when `GOOS=android`, independent of the build host
- [x] Add `GO_LDFLAGS_EXTRA` with `-checklinkname=0` for `GOOS=android`
- [x] Skip the `.so.0` rename/symlink for Android
- [x] Strip the symbol table and DWARF (`-s -w`) for `BUILD_TYPE=release` to reduce library size

# Tests
- [x] `make -n` verified for `build`, `dynamic-library`
- [x] Android (arm64, API 21, NDK 26.1) library built with:
      ```
      GOOS=android GOARCH=arm64 CGO_ENABLED=1 \
        CC=$ANDROID_NDK/toolchains/llvm/prebuilt/<host>/bin/aarch64-linux-android21-clang \
        CXX=$ANDROID_NDK/toolchains/llvm/prebuilt/<host>/bin/aarch64-linux-android21-clang++ \
        BUILD_TYPE=release make dynamic-library
      ```
      and verified loading on-device
- [x] A versioned soname was tested and confirmed **not** loadable on Android, hence the unversioned soname
- [x] No behaviour change for desktop Linux (soname `libgowaku.so.0` + symlink), macOS (`libgowaku.dylib`) or Windows (`libgowaku.dll`)