### PR TITLE
feat(library): add waku_store_query_v3 to the C API

### DIFF
--- a/library/c/api_store.go
+++ b/library/c/api_store.go
@@ -45,6 +45,41 @@ func waku_store_query(ctx unsafe.Pointer, queryJSON *C.char, peerID *C.char, ms 
 	}, ctx, cb, userData)
 }
 
+// Query historic messages using the StoreV3 protocol (/vac/waku/store-query/3.0.0).
+// Use this instead of waku_store_query when the storenode only exposes the v3
+// query protocol (e.g. current nwaku store nodes) rather than the legacy
+// /vac/waku/store/2.0.0-beta4 protocol.
+// queryJSON must contain a valid json string with the following format:
+//
+//	{
+//		"pubsubTopic": "...", // optional string
+//		"startTime": 1234, // optional, unix epoch time in nanoseconds
+//		"endTime": 1234, // optional, unix epoch time in nanoseconds
+//		"contentTopics": [ // optional
+//			"contentTopic1",
+//			...
+//		],
+//		"pagingOptions": {// optional pagination information
+//			"pageSize": 40, // number
+//			"cursor": "...", // optional, opaque base64 byte string returned by a previous call
+//			"forward": true, // sort order
+//		}
+//	}
+//
+// The response `pagingInfo.cursor` is an opaque base64 byte string (NOT the
+// structured legacy cursor). If a non empty cursor is returned, this function
+// should be executed again, setting the `cursor` attribute to page further.
+// peerID should contain the ID of a peer supporting the StoreV3 protocol. Use NULL to automatically select a node
+// If ms is greater than 0, the query must complete before the timeout
+// (in milliseconds) is reached, or an error will be returned
+//
+//export waku_store_query_v3
+func waku_store_query_v3(ctx unsafe.Pointer, queryJSON *C.char, peerID *C.char, ms C.int, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
+	return singleFnExec(func(instance *library.WakuInstance) (string, error) {
+		return library.StoreQueryV3(instance, C.GoString(queryJSON), C.GoString(peerID), int(ms))
+	}, ctx, cb, userData)
+}
+
 // Query historic messages stored in the localDB using waku store protocol.
 // queryJSON must contain a valid json string with the following format:
 //

--- a/library/c/api_store.go
+++ b/library/c/api_store.go
@@ -45,14 +45,13 @@ func waku_store_query(ctx unsafe.Pointer, queryJSON *C.char, peerID *C.char, ms 
 	}, ctx, cb, userData)
 }
 
-// Query historic messages using the StoreV3 protocol (/vac/waku/store-query/3.0.0).
-// Use this instead of waku_store_query when the storenode only exposes the v3
-// query protocol (e.g. current nwaku store nodes) rather than the legacy
+// Query historic messages using the StoreV3 protocol (/vac/waku/store-query/3.0.0),
+// as opposed to waku_store_query which speaks the legacy
 // /vac/waku/store/2.0.0-beta4 protocol.
 // queryJSON must contain a valid json string with the following format:
 //
 //	{
-//		"pubsubTopic": "...", // optional string
+//		"pubsubTopic": "...", // required string
 //		"startTime": 1234, // optional, unix epoch time in nanoseconds
 //		"endTime": 1234, // optional, unix epoch time in nanoseconds
 //		"contentTopics": [ // optional
@@ -66,9 +65,10 @@ func waku_store_query(ctx unsafe.Pointer, queryJSON *C.char, peerID *C.char, ms 
 //		}
 //	}
 //
-// The response `pagingInfo.cursor` is an opaque base64 byte string (NOT the
-// structured legacy cursor). If a non empty cursor is returned, this function
-// should be executed again, setting the `cursor` attribute to page further.
+// The response `pagingInfo` reports the pagination that was actually used, so it
+// can be passed back verbatim to fetch the next page. Its `cursor` is an opaque
+// base64 byte string (NOT the structured legacy cursor). If a non empty cursor is
+// returned, this function should be executed again with that `pagingInfo`.
 // peerID should contain the ID of a peer supporting the StoreV3 protocol. Use NULL to automatically select a node
 // If ms is greater than 0, the query must complete before the timeout
 // (in milliseconds) is reached, or an error will be returned

--- a/library/store_v3.go
+++ b/library/store_v3.go
@@ -1,0 +1,120 @@
+package library
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/waku-org/go-waku/waku/v2/protocol"
+	wpb "github.com/waku-org/go-waku/waku/v2/protocol/pb"
+	"github.com/waku-org/go-waku/waku/v2/protocol/store"
+)
+
+// storeV3PagingOptions mirrors storePagingOptions but uses the StoreV3
+// (`/vac/waku/store-query/3.0.0`) pagination cursor, which is an opaque byte
+// string rather than the legacy structured Index. When marshalled to JSON the
+// cursor is base64-encoded; pass it back verbatim on the next call to page.
+type storeV3PagingOptions struct {
+	PageSize uint64 `json:"pageSize,omitempty"`
+	Cursor   []byte `json:"cursor,omitempty"`
+	Forward  bool   `json:"forward,omitempty"`
+}
+
+type storeV3MessagesArgs struct {
+	Topic         string                `json:"pubsubTopic,omitempty"`
+	ContentTopics []string              `json:"contentTopics,omitempty"`
+	StartTime     *int64                `json:"startTime,omitempty"`
+	EndTime       *int64                `json:"endTime,omitempty"`
+	PagingOptions *storeV3PagingOptions `json:"pagingOptions,omitempty"`
+}
+
+// storeV3MessagesReply intentionally keeps the same `messages` / `pagingInfo` /
+// `error` shape as the legacy storeMessagesReply so existing callers that only
+// read WakuMessage fields can parse it unchanged. The only behavioural
+// difference is that pagingInfo.cursor is an opaque byte string.
+type storeV3MessagesReply struct {
+	Messages   []*wpb.WakuMessage   `json:"messages,omitempty"`
+	PagingInfo storeV3PagingOptions `json:"pagingInfo,omitempty"`
+	Error      string               `json:"error,omitempty"`
+}
+
+// StoreQueryV3 retrieves historic messages using the StoreV3 protocol
+// (`/vac/waku/store-query/3.0.0`). Unlike StoreQuery, which speaks the legacy
+// `/vac/waku/store/2.0.0-beta4` protocol, this talks to storenodes that only
+// expose the v3 query protocol (e.g. current nwaku store nodes).
+//
+// peerID should contain the ID of a peer supporting the StoreV3 protocol. The
+// peer must already be known to the node (e.g. an existing connection). Pass an
+// empty string to let the node select a v3-capable peer automatically.
+func StoreQueryV3(instance *WakuInstance, queryJSON string, peerID string, ms int) (string, error) {
+	if err := validateInstance(instance, MustBeStarted); err != nil {
+		return "", err
+	}
+
+	var args storeV3MessagesArgs
+	if err := json.Unmarshal([]byte(queryJSON), &args); err != nil {
+		return "", err
+	}
+
+	criteria := store.FilterCriteria{
+		ContentFilter: protocol.NewContentFilter(args.Topic, args.ContentTopics...),
+		TimeStart:     args.StartTime,
+		TimeEnd:       args.EndTime,
+	}
+
+	options := []store.RequestOption{
+		store.WithAutomaticRequestID(),
+		store.IncludeData(true),
+	}
+
+	if args.PagingOptions != nil {
+		options = append(options, store.WithPaging(args.PagingOptions.Forward, args.PagingOptions.PageSize))
+		if len(args.PagingOptions.Cursor) != 0 {
+			options = append(options, store.WithCursor(args.PagingOptions.Cursor))
+		}
+	}
+
+	if peerID != "" {
+		p, err := peer.Decode(peerID)
+		if err != nil {
+			return "", err
+		}
+		options = append(options, store.WithPeer(p))
+	} else {
+		options = append(options, store.WithAutomaticPeerSelection())
+	}
+
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if ms > 0 {
+		ctx, cancel = context.WithTimeout(instance.ctx, time.Duration(ms)*time.Millisecond)
+		defer cancel()
+	} else {
+		ctx = instance.ctx
+	}
+
+	result, err := instance.node.Store().Query(ctx, criteria, options...)
+
+	reply := storeV3MessagesReply{}
+	if err != nil {
+		reply.Error = err.Error()
+		return marshalJSON(reply)
+	}
+
+	for _, kv := range result.Messages() {
+		if kv.Message != nil {
+			reply.Messages = append(reply.Messages, kv.Message)
+		}
+	}
+
+	reply.PagingInfo = storeV3PagingOptions{
+		Cursor: result.Cursor(),
+	}
+	if args.PagingOptions != nil {
+		reply.PagingInfo.PageSize = args.PagingOptions.PageSize
+		reply.PagingInfo.Forward = args.PagingOptions.Forward
+	}
+
+	return marshalJSON(reply)
+}

--- a/library/store_v3.go
+++ b/library/store_v3.go
@@ -16,13 +16,15 @@ import (
 // string rather than the legacy structured Index. When marshalled to JSON the
 // cursor is base64-encoded; pass it back verbatim on the next call to page.
 type storeV3PagingOptions struct {
-	PageSize uint64 `json:"pageSize,omitempty"`
+	PageSize uint64 `json:"pageSize"`
 	Cursor   []byte `json:"cursor,omitempty"`
-	Forward  bool   `json:"forward,omitempty"`
+	// Forward is serialised even when false: the reply reports the pagination
+	// actually used, and the caller is expected to pass it back verbatim.
+	Forward bool `json:"forward"`
 }
 
 type storeV3MessagesArgs struct {
-	Topic         string                `json:"pubsubTopic,omitempty"`
+	PubsubTopic   string                `json:"pubsubTopic"`
 	ContentTopics []string              `json:"contentTopics,omitempty"`
 	StartTime     *int64                `json:"startTime,omitempty"`
 	EndTime       *int64                `json:"endTime,omitempty"`
@@ -58,7 +60,7 @@ func StoreQueryV3(instance *WakuInstance, queryJSON string, peerID string, ms in
 	}
 
 	criteria := store.FilterCriteria{
-		ContentFilter: protocol.NewContentFilter(args.Topic, args.ContentTopics...),
+		ContentFilter: protocol.NewContentFilter(args.PubsubTopic, args.ContentTopics...),
 		TimeStart:     args.StartTime,
 		TimeEnd:       args.EndTime,
 	}
@@ -108,12 +110,14 @@ func StoreQueryV3(instance *WakuInstance, queryJSON string, peerID string, ms in
 		}
 	}
 
+	// Report the pagination the query actually used, not what the caller asked
+	// for: when pagingOptions is omitted the store applies its own defaults, and
+	// echoing zero values back would flip the direction on the next call.
+	query := result.Query()
 	reply.PagingInfo = storeV3PagingOptions{
-		Cursor: result.Cursor(),
-	}
-	if args.PagingOptions != nil {
-		reply.PagingInfo.PageSize = args.PagingOptions.PageSize
-		reply.PagingInfo.Forward = args.PagingOptions.Forward
+		PageSize: query.GetPaginationLimit(),
+		Cursor:   result.Cursor(),
+		Forward:  query.GetPaginationForward(),
 	}
 
 	return marshalJSON(reply)


### PR DESCRIPTION
# Description
The C API exposes only `waku_store_query` (legacy `/vac/waku/store/2.0.0-beta4`)
and `waku_store_local_query`. The StoreV3 protocol (`/vac/waku/store-query/3.0.0`)
is fully implemented in Go (`waku/v2/protocol/store`) but has no C binding, so
C/C++ consumers cannot query storenodes that expose only the v3 query protocol —
which is what current nwaku store nodes do.

This adds `waku_store_query_v3`, mirroring the existing `waku_store_query` binding.

# Changes
- [x] Add `waku_store_query_v3` export in `library/c/api_store.go`
- [x] Add `library/store_v3.go` with `StoreQueryV3`, following the same structure as `StoreQuery`
- [x] Keep the reply JSON shape (`messages` / `pagingInfo` / `error`) identical to the legacy binding, so callers reading `WakuMessage` fields parse it unchanged. The only semantic difference is that `pagingInfo.cursor` is an opaque base64 byte string rather than the structured legacy cursor.

# Tests
- [x] `gofmt`, `go vet ./library/...`, `go build ./library/...` clean
- [x] Exercised through the C API against an nwaku storenode

# Notes
- Purely additive (+155/−0): no existing symbol or behaviour is modified.
- `StoreQueryV3` checks `pagingOptions != nil` before use. The legacy `queryResponse`
  dereferences `args.PagingOptions` unconditionally and would panic if a caller omits
  `pagingOptions`; the new binding avoids reproducing that.