### PR TITLE
feat(library): emit peer connection status events in the C API

### DIFF
--- a/library/node.go
+++ b/library/node.go
@@ -39,6 +39,7 @@ type WakuInstance struct {
 
 	node                *node.WakuNode
 	cb                  unsafe.Pointer
+	connCh              chan node.PeerConnection
 	mobileSignalHandler MobileSignalHandler
 
 	relayTopics []string
@@ -127,6 +128,18 @@ func validateInstance(instance *WakuInstance, validationType ValidationType) err
 	return nil
 }
 
+type connectionStatMsg struct {
+	PeerID    string `json:"peerId"`
+	Connected bool   `json:"connected"`
+}
+
+func toConnectionStatus(msg node.PeerConnection) *connectionStatMsg {
+	return &connectionStatMsg{
+		PeerID:    msg.PeerID.String(),
+		Connected: msg.Connected,
+	}
+}
+
 // NewNode initializes a waku node. Receives a JSON string containing the configuration, and use default values for those config items not specified
 func NewNode(instance *WakuInstance, configJSON string) error {
 	if err := validateInstance(instance, NotConfigured); err != nil {
@@ -160,12 +173,15 @@ func NewNode(instance *WakuInstance, configJSON string) error {
 		}
 	}
 
+	instance.connCh = make(chan node.PeerConnection, 10)
+
 	opts := []node.WakuNodeOption{
 		node.WithPrivateKey(prvKey),
 		node.WithHostAddress(hostAddr),
 		node.WithKeepAlive(10*time.Second, time.Duration(*config.KeepAliveInterval)*time.Second),
 		node.WithClusterID(uint16(config.ClusterID)),
 		node.WithShards(config.Shards),
+		node.WithConnectionNotification(instance.connCh),
 	}
 
 	if *config.EnableRelay {
@@ -272,6 +288,21 @@ func Start(instance *WakuInstance) error {
 	// leaves IsStarted() false and Free() will not Stop() a node that never ran.
 	instance.ctx, instance.cancel = ctx, cancel
 
+	go func() {
+		defer utils.LogOnPanic()
+		for {
+			select {
+			case <-instance.ctx.Done():
+				return
+			case item, ok := <-instance.connCh:
+				if !ok {
+					return
+				}
+				send(instance, "conStatus", toConnectionStatus(item))
+			}
+		}
+	}()
+
 	if instance.node.DiscV5() != nil {
 		if err := instance.node.DiscV5().Start(context.Background()); err != nil {
 			stop(instance)
@@ -296,7 +327,14 @@ func Stop(instance *WakuInstance) error {
 		return err
 	}
 
+	// stop() calls node.Stop() which unregisters ConnectionNotifier via StopNotify
+	// before host.Close() fires any disconnect events. Only after that is it safe
+	// to close connCh — closing it first causes a send-on-closed-channel panic.
 	stop(instance)
+	if instance.connCh != nil {
+		close(instance.connCh)
+		instance.connCh = nil
+	}
 
 	return nil
 }

--- a/library/node.go
+++ b/library/node.go
@@ -296,9 +296,10 @@ func Start(instance *WakuInstance) error {
 				return
 			case item, ok := <-instance.connCh:
 				if !ok {
+					utils.Logger().Debug("connection notification channel closed, stopping listener")
 					return
 				}
-				send(instance, "conStatus", toConnectionStatus(item))
+				send(instance, "connectionStatus", toConnectionStatus(item))
 			}
 		}
 	}()


### PR DESCRIPTION
# Description
go-waku can already notify about peer connect/disconnect events via
`node.WithConnectionNotification(ch)`, but the C API does not expose it. C/C++
consumers therefore have no way to observe connectivity changes and must poll
`waku_peer_cnt` to infer them.

This forwards those notifications to the existing signal callback as a
`conStatus` event, so consumers receive them the same way they already receive
other asynchronous events.

# Changes
- [x] Add `connCh chan node.PeerConnection` to `WakuInstance` and register it via `node.WithConnectionNotification`
- [x] Emit a `conStatus` signal carrying `{"peerId": "...", "connected": true|false}`
- [x] Forward notifications from a goroutine started in `Start()`, exiting on `ctx.Done()` or channel close
- [x] Close the channel in `Stop()`, after `stop()` has unregistered the connection notifier

# Tests
- [x] `gofmt`, `go vet ./library/...`, `go build ./library/...` clean
- [x] Verified from a C++ consumer: signals arrive as
      `{"type":"conStatus","event":{"peerId":"16Uiu2HAm...","connected":true}}`

# Notes
- Purely additive (+38/−0): no existing symbol or behaviour changes; consumers that
  ignore `conStatus` are unaffected.
- The channel is closed only after `stop()` runs, because `node.Stop()` unregisters
  the ConnectionNotifier (via `StopNotify`) before `host.Close()` fires disconnect
  events. Closing earlier risks a send-on-closed-channel panic.