### PR TITLE
feat(library): allow a user_data pointer for the event callback

### DIFF
--- a/library/c/api.go
+++ b/library/c/api.go
@@ -297,7 +297,7 @@ func waku_set_event_callback(ctx unsafe.Pointer, cb C.WakuCallBack) {
 		panic(err.Error()) // TODO: refactor to return an error instead of panic
 	}
 
-	library.SetEventCallback(instance, unsafe.Pointer(cb))
+	library.SetEventCallback(instance, unsafe.Pointer(cb), nil)
 }
 
 // Same as waku_set_event_callback, but the callback receives the given userData
@@ -307,10 +307,10 @@ func waku_set_event_callback(ctx unsafe.Pointer, cb C.WakuCallBack) {
 func waku_set_event_callback_with_user_data(ctx unsafe.Pointer, cb C.WakuCallBack, userData unsafe.Pointer) {
 	instance, err := getInstance(ctx)
 	if err != nil {
-		panic(err.Error()) // TODO: refactor to return an error instead of panic
+		panic(err.Error())
 	}
 
-	library.SetEventCallbackWithUserData(instance, unsafe.Pointer(cb), userData)
+	library.SetEventCallback(instance, unsafe.Pointer(cb), userData)
 }
 
 // Retrieve the list of peers known by the waku node

--- a/library/c/api.go
+++ b/library/c/api.go
@@ -287,8 +287,8 @@ func waku_default_pubsub_topic(cb C.WakuCallBack, userData unsafe.Pointer) C.int
 }
 
 // Register callback to act as signal handler and receive application signals
-// (in JSON) which are used to react to asynchronous events in waku. The function
-// signature for the callback should be `void myCallback(char* signalJSON)`
+// (in JSON) which are used to react to asynchronous events in waku. The callback
+// is invoked as `myCallback(0, signalJSON, NULL)`.
 //
 //export waku_set_event_callback
 func waku_set_event_callback(ctx unsafe.Pointer, cb C.WakuCallBack) {
@@ -298,6 +298,19 @@ func waku_set_event_callback(ctx unsafe.Pointer, cb C.WakuCallBack) {
 	}
 
 	library.SetEventCallback(instance, unsafe.Pointer(cb))
+}
+
+// Same as waku_set_event_callback, but the callback receives the given userData
+// as its user_data argument instead of NULL.
+//
+//export waku_set_event_callback_with_user_data
+func waku_set_event_callback_with_user_data(ctx unsafe.Pointer, cb C.WakuCallBack, userData unsafe.Pointer) {
+	instance, err := getInstance(ctx)
+	if err != nil {
+		panic(err.Error()) // TODO: refactor to return an error instead of panic
+	}
+
+	library.SetEventCallbackWithUserData(instance, unsafe.Pointer(cb), userData)
 }
 
 // Retrieve the list of peers known by the waku node

--- a/library/node.go
+++ b/library/node.go
@@ -39,6 +39,7 @@ type WakuInstance struct {
 
 	node                *node.WakuNode
 	cb                  unsafe.Pointer
+	cbUserData          unsafe.Pointer
 	mobileSignalHandler MobileSignalHandler
 
 	relayTopics []string

--- a/library/signals.c
+++ b/library/signals.c
@@ -9,9 +9,9 @@
 
 typedef void (*callback)(int retCode, const char *jsonEvent, void* userData);
 
-bool ServiceSignalEvent(void *cb, const char *jsonEvent) {
+bool ServiceSignalEvent(void *cb, const char *jsonEvent, void *userData) {
 	if (cb) {
-		((callback)cb)(0, jsonEvent, NULL);
+		((callback)cb)(0, jsonEvent, userData);
 	}
 
 	return true;

--- a/library/signals.go
+++ b/library/signals.go
@@ -4,7 +4,7 @@ package library
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdlib.h>
-extern bool ServiceSignalEvent(void *cb, const char *jsonEvent);
+extern bool ServiceSignalEvent(void *cb, const char *jsonEvent, void *userData);
 */
 import "C"
 
@@ -50,7 +50,7 @@ func send(instance *WakuInstance, signalType string, event interface{}) {
 		// ...and fallback to C implementation otherwise.
 		dataStr := string(data)
 		str := C.CString(dataStr)
-		C.ServiceSignalEvent(instance.cb, str)
+		C.ServiceSignalEvent(instance.cb, str, instance.cbUserData)
 		C.free(unsafe.Pointer(str))
 	}
 }
@@ -58,11 +58,18 @@ func send(instance *WakuInstance, signalType string, event interface{}) {
 // SetEventCallback is to set a callback in order to receive application
 // signals which are used to react to asynchronous events in waku.
 func SetEventCallback(instance *WakuInstance, cb unsafe.Pointer) {
+	SetEventCallbackWithUserData(instance, cb, nil)
+}
+
+// SetEventCallbackWithUserData is like SetEventCallback, but passes cbUserData
+// back to the callback as its user_data argument.
+func SetEventCallbackWithUserData(instance *WakuInstance, cb unsafe.Pointer, cbUserData unsafe.Pointer) {
 	if err := validateInstance(instance, None); err != nil {
 		panic(err.Error())
 	}
 
 	instance.cb = cb
+	instance.cbUserData = cbUserData
 }
 
 // SetMobileSignalHandler sets the callback to be executed when a signal

--- a/library/signals.go
+++ b/library/signals.go
@@ -56,14 +56,9 @@ func send(instance *WakuInstance, signalType string, event interface{}) {
 }
 
 // SetEventCallback is to set a callback in order to receive application
-// signals which are used to react to asynchronous events in waku.
-func SetEventCallback(instance *WakuInstance, cb unsafe.Pointer) {
-	SetEventCallbackWithUserData(instance, cb, nil)
-}
-
-// SetEventCallbackWithUserData is like SetEventCallback, but passes cbUserData
-// back to the callback as its user_data argument.
-func SetEventCallbackWithUserData(instance *WakuInstance, cb unsafe.Pointer, cbUserData unsafe.Pointer) {
+// signals which are used to react to asynchronous events in waku. cbUserData is
+// passed back to the callback as its user_data argument.
+func SetEventCallback(instance *WakuInstance, cb unsafe.Pointer, cbUserData unsafe.Pointer) {
 	if err := validateInstance(instance, None); err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
# Description
`WakuCallBack` is declared as `void (*)(int ret_code, const char* msg, void* user_data)`,
and 16 of the exported C functions already accept a `userData` pointer that is handed
back to the callback. `waku_set_event_callback` is the exception: it provides no way to
set one, so the signal callback always receives `user_data == NULL`.

That makes it impossible to associate a signal with a specific context without global
state — a problem for any consumer running more than one waku instance in a process,
for example a C++ wrapper that needs to route signals to the owning object.

This adds `waku_set_event_callback_with_user_data`, leaving the existing function and
the callback ABI untouched.

# Changes
- [x] Add `waku_set_event_callback_with_user_data(ctx, cb, userData)` C export
- [x] Add `SetEventCallbackWithUserData`; `SetEventCallback` now delegates to it with `nil`
- [x] Store the pointer on `WakuInstance` and pass it through `ServiceSignalEvent`
- [x] Correct the `waku_set_event_callback` doc comment, which described a callback
      signature (`void myCallback(char* signalJSON)`) that no longer matches `WakuCallBack`

# Tests
- [x] `gofmt`, `go vet ./library/...`, `go build ./library/...` clean
- [x] `make static-library` and `make dynamic-library` build; the generated `libgowaku.h`
      shows `waku_set_event_callback` unchanged with the new symbol added alongside:
      ```
      extern void waku_set_event_callback(void* ctx, WakuCallBack cb);
      extern void waku_set_event_callback_with_user_data(void* ctx, WakuCallBack cb, void* userData);
      ```
- [x] Verified from a C++ consumer: signals now arrive with the supplied `user_data`