### PR TITLE
fix(rendezvous): select only dialable points so backoff is respected

### DIFF
--- a/waku/v2/rendezvous/iterator.go
+++ b/waku/v2/rendezvous/iterator.go
@@ -47,7 +47,7 @@ func (r *RendezvousPointIterator) Next(ctx context.Context) <-chan *RendezvousPo
 	result := make(chan *RendezvousPoint, 1)
 
 	if len(dialableRP) > 0 {
-		result <- r.rendezvousPoints[rand.Intn(len(r.rendezvousPoints))] // nolint: gosec
+		result <- dialableRP[rand.Intn(len(dialableRP))] // nolint: gosec
 	} else {
 		if len(r.rendezvousPoints) > 0 {
 			sort.Slice(r.rendezvousPoints, func(i, j int) bool {

--- a/waku/v2/rendezvous/iterator_test.go
+++ b/waku/v2/rendezvous/iterator_test.go
@@ -1,0 +1,37 @@
+package rendezvous
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIteratorSkipsPointsInBackoff verifies that a rendezvous point whose backoff
+// has not elapsed yet is never handed out by the iterator while another point is
+// ready to be dialed.
+func TestIteratorSkipsPointsInBackoff(t *testing.T) {
+	ready := NewRendezvousPoint(peer.ID("ready"))
+	backedOff := NewRendezvousPoint(peer.ID("backed-off"))
+
+	// ready has no pending backoff, so it is dialable right away.
+	ready.nextTry = time.Now().Add(-time.Minute)
+
+	// backedOff failed to connect, so it must not be dialed until its backoff expires.
+	backedOff.Delay()
+	require.True(t, backedOff.NextTry().After(time.Now()), "backed off point should not be dialable yet")
+
+	iterator := &RendezvousPointIterator{
+		rendezvousPoints: []*RendezvousPoint{ready, backedOff},
+	}
+
+	// The selection is random, so repeat it enough times to catch a point that
+	// should have been filtered out.
+	for i := 0; i < 100; i++ {
+		rp := <-iterator.Next(context.Background())
+		require.NotNil(t, rp)
+		require.Equal(t, ready.id, rp.id, "iterator returned a rendezvous point that is still in backoff")
+	}
+}


### PR DESCRIPTION
# Description

`RendezvousPointIterator.Next()` builds `dialableRP`, the list of rendezvous points whose backoff has already elapsed, but then picks the point it returns from the full `r.rendezvousPoints` slice:

```go
if len(dialableRP) > 0 {
    result <- r.rendezvousPoints[rand.Intn(len(r.rendezvousPoints))]
}
```

`dialableRP` is only used for the emptiness check, so the filtering has no effect on the returned value. A rendezvous point that just failed to connect, and had `Delay()` applied to it, can be handed out again on the very next call while its `nextTry` is still in the future. With N points of which only one is dialable, the iterator returns a point that is still backing off with probability (N-1)/N.

This defeats the exponential backoff (30s to 1h) configured in `NewRendezvousPoint`, so unreachable rendezvous points keep being dialed at full rate.

# Changes

- [x] `Next()` now picks the returned point from `dialableRP` instead of the full list
- [x] Added `TestIteratorSkipsPointsInBackoff` covering the case

# Tests

```
go test ./waku/v2/rendezvous/ -run TestIteratorSkipsPointsInBackoff -count=5
```

The new test fails on master:

```
    Error:      Not equal:
                expected: "ready"
                actual  : "backed-off"
    Messages:   iterator returned a rendezvous point that is still in backoff
--- FAIL: TestIteratorSkipsPointsInBackoff (0.00s)
```

and passes with the fix applied.

Note: `TestRendezvous` in the same package fails both with and without this change on a `CGO_ENABLED=0` build, because `go-sqlite3` needs cgo. That is unrelated to this fix.
