### PR TITLE
fix(peermanager): order ping results by connectedness then RTT

### DIFF
--- a/waku/v2/peermanager/fastest_peer_selector.go
+++ b/waku/v2/peermanager/fastest_peer_selector.go
@@ -170,5 +170,8 @@ func init() {
 }
 
 func (a pingSort) Less(i, j int) bool {
-	return connectednessPriority[a[i].connectedness] < connectednessPriority[a[j].connectedness] && a[i].rtt < a[j].rtt
+	if connectednessPriority[a[i].connectedness] != connectednessPriority[a[j].connectedness] {
+		return connectednessPriority[a[i].connectedness] < connectednessPriority[a[j].connectedness]
+	}
+	return a[i].rtt < a[j].rtt
 }

--- a/waku/v2/peermanager/fastest_peer_selector_test.go
+++ b/waku/v2/peermanager/fastest_peer_selector_test.go
@@ -3,9 +3,11 @@ package peermanager
 import (
 	"context"
 	"crypto/rand"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/stretchr/testify/require"
@@ -45,4 +47,34 @@ func TestRTT(t *testing.T) {
 			require.NotEqual(t, h3.ID(), p)
 		}
 	}
+}
+
+// TestPingSortOrdersByRTT verifies that peers sharing the same connectedness are
+// ordered by round trip time, so that FastestPeer returns the fastest one.
+func TestPingSortOrdersByRTT(t *testing.T) {
+	results := []pingResult{
+		{peerID: "slow", rtt: 500 * time.Millisecond, connectedness: network.Connected},
+		{peerID: "fast", rtt: 10 * time.Millisecond, connectedness: network.Connected},
+		{peerID: "medium", rtt: 100 * time.Millisecond, connectedness: network.Connected},
+	}
+
+	sort.Sort(pingSort(results))
+
+	require.Equal(t, peer.ID("fast"), results[0].peerID)
+	require.Equal(t, peer.ID("medium"), results[1].peerID)
+	require.Equal(t, peer.ID("slow"), results[2].peerID)
+}
+
+// TestPingSortPrefersConnectedPeers verifies that connectedness stays the primary
+// criteria, even when a less connected peer has a lower round trip time.
+func TestPingSortPrefersConnectedPeers(t *testing.T) {
+	results := []pingResult{
+		{peerID: "not-connected", rtt: 10 * time.Millisecond, connectedness: network.NotConnected},
+		{peerID: "connected", rtt: 500 * time.Millisecond, connectedness: network.Connected},
+	}
+
+	sort.Sort(pingSort(results))
+
+	require.Equal(t, peer.ID("connected"), results[0].peerID)
+	require.Equal(t, peer.ID("not-connected"), results[1].peerID)
 }


### PR DESCRIPTION
# Description

`pingSort.Less` combines the two ordering criteria with `&&`:

```go
func (a pingSort) Less(i, j int) bool {
	return connectednessPriority[a[i].connectedness] < connectednessPriority[a[j].connectedness] && a[i].rtt < a[j].rtt
}
```

This only reports `i` as smaller when it wins on *both* criteria at once, so it does not implement the strict weak ordering `sort.Interface` requires, and both criteria end up being ignored in the common cases:

- Two peers with the same connectedness: the left operand is false, so `Less` is false in both directions and the peers are treated as equal. RTT never orders them, even though `FastestPeer` pings peers precisely to compare their RTT.
- A better connected peer with a higher RTT: `Less(better, worse)` is false because of the RTT term and `Less(worse, better)` is false because of the connectedness term, so these are treated as equal too and connectedness does not win.

The criteria are meant to be applied in order: connectedness first, RTT as the tie breaker.

# Changes

- [x] `Less` now compares connectedness first and falls back to RTT when it is equal
- [x] Added `TestPingSortOrdersByRTT` and `TestPingSortPrefersConnectedPeers`

# Tests

```
go test ./waku/v2/peermanager/ -run TestPingSort -count=1
```

Both tests fail on master and pass with the fix.

`TestPingSortOrdersByRTT` — three peers that are all `Connected` keep their input order:

```
expected: "fast"
actual  : "slow"
```

`TestPingSortPrefersConnectedPeers` — a `Connected` peer with a higher RTT is not ordered ahead of a `NotConnected` one:

```
expected: "connected"
actual  : "not-connected"
```
