### PR TITLE
fix(protocol): reject content topics that do not start with a slash

### DIFF
--- a/waku/v2/protocol/content_topic.go
+++ b/waku/v2/protocol/content_topic.go
@@ -88,6 +88,10 @@ func (ct ContentTopic) Equal(ct2 ContentTopic) bool {
 // For static and named-sharding, contentTopic can be of any format and hence it is not recommended to use this function.
 // This can be updated if required to handle such a case.
 func StringToContentTopic(s string) (ContentTopic, error) {
+	if !strings.HasPrefix(s, "/") {
+		return ContentTopic{}, ErrInvalidFormat
+	}
+
 	p := strings.Split(s, "/")
 	switch len(p) {
 	case 5:

--- a/waku/v2/protocol/filter/filter_test.go
+++ b/waku/v2/protocol/filter/filter_test.go
@@ -99,7 +99,7 @@ func (s *FilterTestSuite) TestAutoShard() {
 	s.ctx = ctx
 	s.ctxCancel = cancel
 
-	cTopic1Str := "0/test/1/testTopic/proto"
+	cTopic1Str := "/0/test/1/testTopic/proto"
 	cTopic1, err := protocol.StringToContentTopic(cTopic1Str)
 	s.Require().NoError(err)
 	//Computing pubSubTopic only for filterFullNode.
@@ -136,7 +136,7 @@ func (s *FilterTestSuite) TestAutoShard() {
 	// Test ModifySubscription Subscribe to another content_topic
 	s.Log.Info("Testing Autoshard:ModifySubscription")
 
-	newContentTopic := "0/test/1/testTopic1/proto"
+	newContentTopic := "/0/test/1/testTopic1/proto"
 	s.subscribe("", newContentTopic, s.FullNodeHost.ID())
 
 	s.waitForMsg(&WakuMsg{s.TestTopic, newContentTopic, ""})

--- a/waku/v2/protocol/lightpush/waku_lightpush_test.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_test.go
@@ -187,7 +187,7 @@ func TestWakuLightPushNoPeers(t *testing.T) {
 // Node1 receive the message
 
 func TestWakuLightPushAutoSharding(t *testing.T) {
-	contentTopic := "0/test/1/testTopic/proto"
+	contentTopic := "/0/test/1/testTopic/proto"
 	cTopic1, err := protocol.StringToContentTopic(contentTopic)
 	require.NoError(t, err)
 	//Computing pubSubTopic only for filterFullNode.

--- a/waku/v2/protocol/topic_test.go
+++ b/waku/v2/protocol/topic_test.go
@@ -55,6 +55,17 @@ func TestContentTopicAndSharding(t *testing.T) {
 	require.Equal(t, ct5.Generation, 0)
 }
 
+func TestStringToContentTopicRequiresLeadingSlash(t *testing.T) {
+	// A content topic is /{application}/{version}/{topic-name}/{encoding}, so any
+	// text before the first slash makes the string an invalid content topic.
+	_, err := StringToContentTopic("waku/2/test/proto/extra")
+	require.ErrorIs(t, err, ErrInvalidFormat)
+
+	// Same with the optional generation part.
+	_, err = StringToContentTopic("waku/0/toychat/2/huilong/proto")
+	require.ErrorIs(t, err, ErrInvalidFormat)
+}
+
 func randomContentTopic() (ContentTopic, error) {
 	var app = ""
 	const WordLength = 5


### PR DESCRIPTION
# Description

`StringToContentTopic` splits the string on `/` and only reads the parts after the first one:

```go
p := strings.Split(s, "/")
switch len(p) {
case 5:
	...
	return ContentTopic{
		ApplicationName:    p[1],
		ApplicationVersion: p[2],
		...
```

`p[0]` is never checked, so a string with text before the leading slash is accepted and that text is silently dropped:

```
StringToContentTopic("waku/2/test/proto/extra")
  -> ContentTopic{ApplicationName: "2", ApplicationVersion: "test", ContentTopicName: "proto", Encoding: "extra"}
```

`ContentTopic.String()` then returns `/2/test/proto/extra`, which is not what was passed in, and `GetShardFromContentTopic` derives the shard from an application name and version that were never intended, so the message ends up on a different pubsub topic.

`topic_test.go` already covers this intent:

```go
_, err = StringToContentTopic("waku/1/a/b")
require.Error(t, err, ErrInvalidFormat)
```

but that string is rejected for having 4 parts rather than for the missing slash, so the 5 and 6 part cases are not caught.

This also explains three test content topics in the repository that are missing the leading slash and are only accepted because of this behaviour:

- `waku/v2/protocol/lightpush/waku_lightpush_test.go`: `"0/test/1/testTopic/proto"`
- `waku/v2/protocol/filter/filter_test.go`: `"0/test/1/testTopic/proto"` and `"0/test/1/testTopic1/proto"`

They read as generation-0 topics but currently parse as `/test/1/testTopic/proto` with the `0` dropped. They are corrected here, since they would otherwise fail with this change. The derived shard is unaffected, because it only depends on the application name and version, which stay the same either way.

# Changes

- [x] `StringToContentTopic` rejects strings that do not start with `/`
- [x] Added `TestStringToContentTopicRequiresLeadingSlash`
- [x] Corrected the three test content topics that were missing the leading slash

# Tests

```
go test ./waku/v2/protocol/ ./waku/v2/protocol/lightpush/ -count=1
```

`TestStringToContentTopicRequiresLeadingSlash` fails on master:

```
Error: Target error should be in err chain:
       expected: "invalid content topic format"
       in chain:
```

and passes with the fix. `waku/v2/protocol` and `waku/v2/protocol/lightpush` both pass.

Note: `TestFilterSuite/TestUnsubscribeErrorHandling` fails with and without this change in my environment, so it looks unrelated to this fix.
