### PR TITLE
feat(library): identify the emitting instance in every signal

### DIFF
--- a/examples/c-bindings/main.c
+++ b/examples/c-bindings/main.c
@@ -56,7 +56,7 @@ void callBack(int ret, const char *signal, void *user_data)
 
   // Example signal:
   /*{
-      "nodeId":1,
+      "instanceId":0,
       "type":"message",
       "event":{
         "pubsubTopic":"/waku/2/default-waku/proto",

--- a/library/c/README.md
+++ b/library/c/README.md
@@ -200,6 +200,7 @@ When an event is emitted, this callback will be triggered receiving a JSON strin
 
 ```ts
 {
+    instanceId: number;
     type: string;
     event: any;
 }
@@ -207,6 +208,7 @@ When an event is emitted, this callback will be triggered receiving a JSON strin
 
 Fields:
 
+- `instanceId`: Id of the waku instance that emitted the signal.
 - `type`: Type of signal being emitted. Currently, only `message` is available.
 - `event`: Format depends on the type of signal.
 
@@ -214,6 +216,7 @@ For example:
 
 ```json
 {
+  "instanceId": 0,
   "type": "message",
   "event": {
     "pubsubTopic": "/waku/2/default-waku/proto",
@@ -248,15 +251,39 @@ Type of `event` field for a `message` event:
 - `messageId`: The message id.
 - `wakuMessage`: The message in [`JsonMessage`](#jsonmessage-type) format.
 
-### `extern void waku_set_event_callback(WakuCallBack cb)`
+### `extern int waku_instance_id(void* ctx, WakuCallBack cb, void* userData)`
+
+Get the id of a waku instance. The id is unique for the lifetime of the process and is
+never reused, so it is safe to keep as a key for as long as the instance lives.
+
+**Parameters**
+
+1. `void* ctx`: waku node instance, returned by `waku_init`.
+2. `WakuCallBack cb`: callback to be executed.
+3. `void* userData`: used to pass custom information to the callback function
+
+**Returns**
+
+A status code. Refer to the [`Status codes`](#status-codes) section for possible values.
+If the function execution fails, `cb` will receive a string containing an error.
+If the function is executed succesfully, `cb` will receive the id as a decimal string,
+for example `0`. It matches the `instanceId` field of every
+[`JsonSignal`](#jsonsignal-type) the instance emits.
+
+### `extern void waku_set_event_callback(void* ctx, WakuCallBack cb)`
 
 Register callback to act as event handler and receive application signals,
 which are used to react to asynchronous events in Waku.
 
 **Parameters**
 
-1. `WakuCallBack cb`: callback that will be executed when an async event is emitted.
-  The function signature for the callback should be `void myCallback(char* signal, void * user_data)`
+1. `void* ctx`: waku node instance, returned by `waku_init`.
+2. `WakuCallBack cb`: callback that will be executed when an async event is emitted.
+  It is invoked as `cb(0, signalJSON, NULL)`, where `signalJSON` is a
+  [`JsonSignal`](#jsonsignal-type).
+
+To handle signals from several instances, register the same callback on each of them
+and dispatch on the `instanceId` field of the signal.
 
 ## Node management
 

--- a/library/c/api.go
+++ b/library/c/api.go
@@ -15,6 +15,7 @@ typedef void (*WakuCallBack) (int ret_code, const char* msg, void * user_data);
 import "C"
 import (
 	"fmt"
+	"strconv"
 	"unsafe"
 
 	"github.com/waku-org/go-waku/library"
@@ -286,9 +287,25 @@ func waku_default_pubsub_topic(cb C.WakuCallBack, userData unsafe.Pointer) C.int
 	return onSuccesfulResponse(library.DefaultPubsubTopic(), cb, userData)
 }
 
+// Retrieve the id of a waku instance, as a decimal string. The id is unique for
+// the lifetime of the process and is never reused. It is reported as the
+// `instanceId` field of every signal the instance emits, which lets a consumer
+// running several instances route a signal back to the one that emitted it.
+//
+//export waku_instance_id
+func waku_instance_id(ctx unsafe.Pointer, cb C.WakuCallBack, userData unsafe.Pointer) C.int {
+	instance, err := getInstance(ctx)
+	if err != nil {
+		return onError(err, cb, userData)
+	}
+
+	return onSuccesfulResponse(strconv.FormatUint(uint64(instance.ID), 10), cb, userData)
+}
+
 // Register callback to act as signal handler and receive application signals
-// (in JSON) which are used to react to asynchronous events in waku. The function
-// signature for the callback should be `void myCallback(char* signalJSON)`
+// (in JSON) which are used to react to asynchronous events in waku. The callback
+// is invoked as `myCallback(0, signalJSON, NULL)`. The `instanceId` field of
+// signalJSON identifies the instance the signal came from.
 //
 //export waku_set_event_callback
 func waku_set_event_callback(ctx unsafe.Pointer, cb C.WakuCallBack) {

--- a/library/node.go
+++ b/library/node.go
@@ -35,7 +35,10 @@ import (
 type WakuInstance struct {
 	ctx    context.Context
 	cancel context.CancelFunc
-	ID     uint
+
+	// ID identifies this instance. It is unique for the lifetime of the process
+	// and never reused, and is reported in every signal the instance emits.
+	ID uint
 
 	node                *node.WakuNode
 	cb                  unsafe.Pointer
@@ -46,6 +49,7 @@ type WakuInstance struct {
 
 var wakuInstances map[uint]*WakuInstance
 var wakuInstancesMutex sync.RWMutex
+var nextInstanceID uint
 
 var errWakuNodeNotReady = errors.New("not initialized")
 var errWakuNodeAlreadyConfigured = errors.New("already configured")
@@ -69,7 +73,9 @@ func Init() *WakuInstance {
 	wakuInstancesMutex.Lock()
 	defer wakuInstancesMutex.Unlock()
 
-	id := uint(len(wakuInstances))
+	id := nextInstanceID
+	nextInstanceID++
+
 	instance := &WakuInstance{
 		ID: id,
 	}

--- a/library/signals.go
+++ b/library/signals.go
@@ -22,22 +22,26 @@ var mobileSignalHandler MobileSignalHandler
 
 // signalEnvelope is a general signal sent upward from node to app
 type signalEnvelope struct {
-	Type  string      `json:"type"`
-	Event interface{} `json:"event"`
+	// InstanceID identifies the waku instance that emitted the signal, so that
+	// a consumer running several instances can route it to the right one.
+	InstanceID uint        `json:"instanceId"`
+	Type       string      `json:"type"`
+	Event      interface{} `json:"event"`
 }
 
 // NewEnvelope creates new envlope of given type and event payload.
-func newEnvelope(signalType string, event interface{}) *signalEnvelope {
+func newEnvelope(instanceID uint, signalType string, event interface{}) *signalEnvelope {
 	return &signalEnvelope{
-		Type:  signalType,
-		Event: event,
+		InstanceID: instanceID,
+		Type:       signalType,
+		Event:      event,
 	}
 }
 
 // send sends application signal (in JSON) upwards to application (via default notification handler)
 func send(instance *WakuInstance, signalType string, event interface{}) {
 
-	signal := newEnvelope(signalType, event)
+	signal := newEnvelope(instance.ID, signalType, event)
 	data, err := json.Marshal(&signal)
 	if err != nil {
 		fmt.Println("marshal signal error", err)

--- a/library/signals_test.go
+++ b/library/signals_test.go
@@ -1,0 +1,39 @@
+package library
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignalCarriesInstanceID checks that a signal identifies the instance that
+// emitted it, so a consumer running several instances can route it.
+func TestSignalCarriesInstanceID(t *testing.T) {
+	first := Init()
+	defer func() { _ = Free(first) }()
+	second := Init()
+	defer func() { _ = Free(second) }()
+
+	var received [][]byte
+	handler := func(data []byte) { received = append(received, data) }
+	SetMobileSignalHandler(first, handler)
+	SetMobileSignalHandler(second, handler)
+
+	send(second, "message", map[string]string{"payload": "hello"})
+	send(first, "message", map[string]string{"payload": "world"})
+
+	require.Len(t, received, 2)
+	require.Equal(t, second.ID, decodeInstanceID(t, received[0]))
+	require.Equal(t, first.ID, decodeInstanceID(t, received[1]))
+}
+
+func decodeInstanceID(t *testing.T, data []byte) uint {
+	t.Helper()
+
+	var envelope struct {
+		InstanceID uint `json:"instanceId"`
+	}
+	require.NoError(t, json.Unmarshal(data, &envelope))
+	return envelope.InstanceID
+}


### PR DESCRIPTION
# Description

`waku_set_event_callback(ctx, cb)` already registers the callback per instance, but the signal itself carries no identity. A consumer running more than one waku instance in a process registers the same function pointer on each of them — a C++ wrapper has one static trampoline, it cannot synthesise a distinct function pointer per object — and then has no way to tell which instance a signal came from.

This tags every signal with the id of the instance that emitted it, and adds `waku_instance_id` so a C consumer can map its opaque `ctx` to that id and build a routing table.

Alternative to #1319, which solves the same problem by threading a `user_data` pointer
through to the callback. Trade-offs in the section below; happy to take either, or both.
